### PR TITLE
style: format code with Autopep8, Black, isort, Ruff Formatter and Yapf

### DIFF
--- a/Decatalogo_evaluador.py
+++ b/Decatalogo_evaluador.py
@@ -9,6 +9,7 @@ Conexión: INTEGRACIÓN TOTAL con todos los módulos del proyecto
 Autor: Sistema Doctoral de Políticas Públicas - Versión Industrial
 Fecha: 2025 - Versión de Producción
 """
+
 import json
 import logging
 import sys
@@ -23,7 +24,7 @@ from contradiction_detector import (
     ContradictionAnalysis,
     ContradictionDetector,
     ContradictionMatch,
-    )
+)
 
 # Importaciones del sistema principal (Decatalogo_principal.py)
 from Decatalogo_principal import (  # Clases adicionales necesarias

--- a/causal_pattern_detector.py
+++ b/causal_pattern_detector.py
@@ -1,18 +1,19 @@
 # coding=utf-8
-import numpy as np
-import pandas as pd
-from sklearn.ensemble import RandomForestRegressor
-from sklearn.preprocessing import StandardScaler
-import networkx as nx
-import torch
-import torch.nn as nn
-from torch.utils.data import DataLoader, TensorDataset
-import dcor
-import pygam
-from econml.dml import CausalForestDML
 import warnings
 
-warnings.filterwarnings('ignore')
+import dcor
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pygam
+import torch
+import torch.nn as nn
+from econml.dml import CausalForestDML
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import DataLoader, TensorDataset
+
+warnings.filterwarnings("ignore")
 
 
 class IndustrialCausalPatternDetector:
@@ -38,7 +39,7 @@ class IndustrialCausalPatternDetector:
         numeric_columns = data.select_dtypes(include=[np.number]).columns
         scaler = StandardScaler()
         data[numeric_columns] = scaler.fit_transform(data[numeric_columns])
-        self.scalers['main'] = scaler
+        self.scalers["main"] = scaler
 
         return data
 
@@ -50,12 +51,12 @@ class IndustrialCausalPatternDetector:
         numeric_data = data.select_dtypes(include=[np.number])
 
         # Pearson相关系数
-        pearson_corr = numeric_data.corr(method='pearson')
-        results['pearson'] = pearson_corr
+        pearson_corr = numeric_data.corr(method="pearson")
+        results["pearson"] = pearson_corr
 
         # Spearman秩相关
-        spearman_corr = numeric_data.corr(method='spearman')
-        results['spearman'] = spearman_corr
+        spearman_corr = numeric_data.corr(method="spearman")
+        results["spearman"] = spearman_corr
 
         # 距离相关性 (Distance Correlation)
         cols = numeric_data.columns
@@ -67,24 +68,25 @@ class IndustrialCausalPatternDetector:
                 if i == j:
                     dist_corr_matrix[i, j] = 1.0
                 else:
-                    dcor_val = dcor.distance_correlation(numeric_data.iloc[:, i],
-                                                         numeric_data.iloc[:, j])
+                    dcor_val = dcor.distance_correlation(
+                        numeric_data.iloc[:, i], numeric_data.iloc[:, j]
+                    )
                     dist_corr_matrix[i, j] = dcor_val
                     dist_corr_matrix[j, i] = dcor_val
 
-        results['distance_correlation'] = pd.DataFrame(
+        results["distance_correlation"] = pd.DataFrame(
             dist_corr_matrix, columns=cols, index=cols
         )
 
         return results
 
-    def build_causal_graph(self, data, method='pc'):
+    def build_causal_graph(self, data, method="pc"):
         """
         构建因果图
         """
-        if method == 'pc':
+        if method == "pc":
             return self._pc_algorithm(data)
-        elif method == 'ges':
+        elif method == "ges":
             return self._ges_algorithm(data)
         else:
             raise ValueError("Unsupported method")
@@ -146,7 +148,7 @@ class IndustrialCausalPatternDetector:
             model_y=RandomForestRegressor(),
             model_t=RandomForestRegressor(),
             discrete_treatment=False,
-            cv=3
+            cv=3,
         )
 
         # 拟合模型
@@ -157,9 +159,9 @@ class IndustrialCausalPatternDetector:
         confidence_intervals = est.effect_interval(X, alpha=0.05)
 
         return {
-            'causal_effect': causal_effect,
-            'confidence_intervals': confidence_intervals,
-            'model': est
+            "causal_effect": causal_effect,
+            "confidence_intervals": confidence_intervals,
+            "model": est,
         }
 
     def deep_causal_inference(self, data, treatment, outcome, confounders):
@@ -168,28 +170,26 @@ class IndustrialCausalPatternDetector:
         """
         # 数据准备
         X = torch.tensor(data[confounders].values, dtype=torch.float32)
-        T = torch.tensor(data[treatment].values, dtype=torch.float32).unsqueeze(1)
-        Y = torch.tensor(data[outcome].values, dtype=torch.float32).unsqueeze(1)
+        T = torch.tensor(data[treatment].values,
+                         dtype=torch.float32).unsqueeze(1)
+        Y = torch.tensor(data[outcome].values,
+                         dtype=torch.float32).unsqueeze(1)
 
         # 构建神经网络模型
         class CausalNet(nn.Module):
             def __init__(self, input_dim):
                 super(CausalNet, self).__init__()
                 self.shared_layers = nn.Sequential(
-                    nn.Linear(input_dim, 128),
-                    nn.ReLU(),
-                    nn.Linear(128, 64),
-                    nn.ReLU()
+                    nn.Linear(input_dim, 128), nn.ReLU(
+                    ), nn.Linear(128, 64), nn.ReLU()
                 )
                 self.treatment_layer = nn.Sequential(
-                    nn.Linear(64, 32),
-                    nn.ReLU(),
-                    nn.Linear(32, 1)
+                    nn.Linear(64, 32), nn.ReLU(), nn.Linear(32, 1)
                 )
                 self.outcome_layer = nn.Sequential(
-                    nn.Linear(65, 32),  # 64 + 1 (treatment)
+                    nn.Linear(65, 32),
                     nn.ReLU(),
-                    nn.Linear(32, 1)
+                    nn.Linear(32, 1),  # 64 + 1 (treatment)
                 )
 
             def forward(self, x, t):
@@ -223,10 +223,7 @@ class IndustrialCausalPatternDetector:
             y_t0, _ = model(X, torch.zeros_like(T))
             causal_effect = (y_t1 - y_t0).numpy().flatten()
 
-        return {
-            'causal_effect': causal_effect,
-            'model': model
-        }
+        return {"causal_effect": causal_effect, "model": model}
 
     def gam_causal_analysis(self, data, treatment, outcome, confounders):
         """
@@ -238,7 +235,7 @@ class IndustrialCausalPatternDetector:
 
         # 构建GAM模型
         # 为每个特征创建spline项
-        formula = ' + '.join([f's({col})' for col in confounders + [treatment]])
+        formula = " + ".join([f"s({col})" for col in confounders + [treatment]])
 
         # 由于pygam的API限制，我们手动构建模型
         gam = pygam.GAM()
@@ -248,10 +245,7 @@ class IndustrialCausalPatternDetector:
         treatment_idx = X.columns.get_loc(treatment)
         treatment_effect = gam.coef_[treatment_idx]
 
-        return {
-            'treatment_effect': treatment_effect,
-            'model': gam
-        }
+        return {"treatment_effect": treatment_effect, "model": gam}
 
     def detect_anomalies_in_causal_patterns(self, data, reference_patterns):
         """
@@ -273,9 +267,9 @@ class IndustrialCausalPatternDetector:
                 anomaly_positions = np.where(diff > threshold)
 
                 anomalies[pattern_type] = {
-                    'score': anomaly_score,
-                    'positions': list(zip(anomaly_positions[0], anomaly_positions[1])),
-                    'details': diff
+                    "score": anomaly_score,
+                    "positions": list(zip(anomaly_positions[0], anomaly_positions[1])),
+                    "details": diff,
                 }
 
         return anomalies
@@ -295,9 +289,9 @@ class IndustrialCausalPatternDetector:
 
         # 存储结果
         self.results = {
-            'correlation_patterns': correlation_patterns,
-            'causal_graph': causal_graph,
-            'processed_data': processed_data
+            "correlation_patterns": correlation_patterns,
+            "causal_graph": causal_graph,
+            "processed_data": processed_data,
         }
 
         return self.results
@@ -316,13 +310,7 @@ def main():
     X4 = 0.7 * X3 + np.random.normal(0, 0.5, n_samples)
     Y = 1.2 * X3 + 0.8 * X4 + np.random.normal(0, 0.5, n_samples)
 
-    data = pd.DataFrame({
-        'X1': X1,
-        'X2': X2,
-        'X3': X3,
-        'X4': X4,
-        'Y': Y
-    })
+    data = pd.DataFrame({"X1": X1, "X2": X2, "X3": X3, "X4": X4, "Y": Y})
 
     # 初始化因果模式检测器
     detector = IndustrialCausalPatternDetector()
@@ -332,13 +320,17 @@ def main():
 
     # 执行特定因果推断
     if len(data.columns) >= 3:
-        confounders = ['X1', 'X2', 'X3']
-        treatment = 'X4'
-        outcome = 'Y'
+        confounders = ["X1", "X2", "X3"]
+        treatment = "X4"
+        outcome = "Y"
 
         # 确保列存在于数据中
         available_cols = [col for col in confounders if col in data.columns]
-        if treatment in data.columns and outcome in data.columns and len(available_cols) > 0:
+        if (
+            treatment in data.columns
+            and outcome in data.columns
+            and len(available_cols) > 0
+        ):
             try:
                 dml_result = detector.causal_inference_dml(
                     data, treatment, outcome, available_cols

--- a/dag_validation.py
+++ b/dag_validation.py
@@ -13,7 +13,7 @@ rigorous statistical validation of causal models and graph structures.
 Statistical Framework:
     - Frequentist p-values with multiple testing corrections
     - Bayesian posterior probabilities for acyclicity
-    - Effect size measurements and power analysis  
+    - Effect size measurements and power analysis
     - Bootstrap confidence intervals
     - Sensitivity to edge perturbations
 
@@ -54,12 +54,12 @@ import hashlib
 import multiprocessing as mp
 import random
 import time
-from collections import defaultdict, deque, Counter
+from collections import Counter, defaultdict, deque
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import List, Tuple, Dict, Set, Any
+from typing import Any, Dict, List, Set, Tuple
 
 import networkx as nx
 import numpy as np
@@ -71,16 +71,17 @@ from json_utils import safe_json_dump, safe_json_dumps
 class GraphType(Enum):
     """
     Types of graph structures for analysis.
-    
+
     Defines different categories of directed graphs that can be analyzed
     with specialized validation approaches for each type.
-    
+
     Attributes:
         CAUSAL_DAG: Causal directed acyclic graph
         BAYESIAN_NETWORK: Bayesian network structure
         STRUCTURAL_MODEL: Structural equation model
         THEORY_OF_CHANGE: Theory of change logical model
     """
+
     CAUSAL_DAG = auto()
     BAYESIAN_NETWORK = auto()
     STRUCTURAL_MODEL = auto()
@@ -90,10 +91,10 @@ class GraphType(Enum):
 class StatisticalTest(Enum):
     """
     Available statistical tests for graph validation.
-    
+
     Comprehensive set of statistical tests for validating different
     aspects of graph structure and properties.
-    
+
     Attributes:
         ACYCLICITY: Test for absence of cycles in the graph
         CONNECTIVITY: Test for graph connectivity properties
@@ -101,6 +102,7 @@ class StatisticalTest(Enum):
         SENSITIVITY: Test for sensitivity to edge perturbations
         ROBUSTNESS: Test for overall structural robustness
     """
+
     ACYCLICITY = auto()
     CONNECTIVITY = auto()
     PATH_ANALYSIS = auto()
@@ -112,10 +114,10 @@ class StatisticalTest(Enum):
 class AdvancedGraphNode:
     """
     Enhanced node representation with metadata and metrics.
-    
+
     Comprehensive node representation that includes dependencies, metadata,
     centrality measures, and role classification for advanced graph analysis.
-    
+
     Args:
         name (str): Node identifier name
         dependencies (Set[str]): Set of parent node names
@@ -123,10 +125,10 @@ class AdvancedGraphNode:
         centrality_measures (Dict[str, float], optional): Centrality metrics. Defaults to empty dict.
         role (str, optional): Node role in analysis. Defaults to "variable".
                               Options: "variable", "intervention", "outcome", "mediator"
-        
+
     Methods:
         __post_init__: Initialize default metadata if not provided
-        
+
     Example:
         >>> node = AdvancedGraphNode(
         ...     name="treatment",
@@ -134,11 +136,12 @@ class AdvancedGraphNode:
         ...     role="intervention",
         ...     metadata={"study_id": "RCT_001"}
         ... )
-        
+
     Note:
         Automatically initializes default metadata including creation timestamp,
         node type, and confidence level if not explicitly provided.
     """
+
     name: str
     dependencies: Set[str]
     metadata: Dict[str, Any] = field(default_factory=dict)
@@ -148,7 +151,7 @@ class AdvancedGraphNode:
     def __post_init__(self):
         """
         Initialize default metadata if not provided.
-        
+
         Sets up standard metadata fields including creation timestamp,
         node type classification, and default confidence level.
         """
@@ -156,13 +159,14 @@ class AdvancedGraphNode:
             self.metadata = {
                 "created": datetime.now().isoformat(),
                 "node_type": "causal",
-                "confidence": 1.0
+                "confidence": 1.0,
             }
 
 
 @dataclass
 class MonteCarloAdvancedResult:
     """Comprehensive results from advanced Monte Carlo testing."""
+
     # Basic identification
     plan_name: str
     seed: int
@@ -205,6 +209,7 @@ class MonteCarloAdvancedResult:
 @dataclass
 class HypothesisTestResult:
     """Results of formal statistical hypothesis testing."""
+
     test_type: StatisticalTest
     null_hypothesis: str
     alternative_hypothesis: str
@@ -222,34 +227,34 @@ class HypothesisTestResult:
 def _create_advanced_seed(plan_name: str, salt: str = "") -> int:
     """
     Create deterministic seed with salt for additional variability.
-    
+
     Generates a deterministic but variable seed based on plan name, optional salt,
     and current date for reproducible yet flexible random number generation.
-    
+
     Args:
         plan_name (str): Base plan name for seed generation
         salt (str, optional): Additional salt for variability. Defaults to "".
-        
+
     Returns:
         int: Deterministic seed value for random number generation
-        
+
     Note:
         Uses SHA512 hashing for robust seed generation with 8-byte seed space
         for enhanced randomization quality in statistical sampling.
     """
     combined_string = f"{plan_name}{salt}{datetime.now().strftime('%Y%m%d')}"
-    hash_obj = hashlib.sha512(combined_string.encode('utf-8'))
+    hash_obj = hashlib.sha512(combined_string.encode("utf-8"))
     seed_bytes = hash_obj.digest()[:8]  # Use 8 bytes for larger seed space
-    seed = int.from_bytes(seed_bytes, byteorder='big', signed=False)
+    seed = int.from_bytes(seed_bytes, byteorder="big", signed=False)
     return seed
 
 
 class AdvancedDAGValidator:
     """Sophisticated DAG validation with multiple statistical approaches and advanced graph analysis capabilities.
-    
+
     This class provides comprehensive validation for Directed Acyclic Graphs (DAGs) using
     Monte Carlo methods, Bayesian analysis, and advanced graph metrics for causal inference.
-    
+
     Attributes:
         graph_nodes: Dictionary mapping node names to AdvancedGraphNode objects.
         graph_type: Type of graph being validated (CAUSAL_DAG, BAYESIAN_NETWORK, etc.).
@@ -257,22 +262,22 @@ class AdvancedDAGValidator:
         validation_history: List of previous validation results.
         hypothesis_tests: List of formal statistical hypothesis test results.
         config: Configuration parameters for validation algorithms.
-    
+
     Comprehensive validation system for directed acyclic graphs incorporating multiple
     statistical testing methods, Bayesian analysis, sensitivity testing, and advanced
     graph metrics. Designed for rigorous validation of causal models and structural graphs.
-    
+
     Args:
-        graph_type (GraphType, optional): Type of graph being analyzed. 
+        graph_type (GraphType, optional): Type of graph being analyzed.
                                          Defaults to GraphType.CAUSAL_DAG.
-    
+
     Attributes:
         graph_nodes (Dict[str, AdvancedGraphNode]): Dictionary of graph nodes
         graph_type (GraphType): Graph type classification
         validation_history (List[MonteCarloAdvancedResult]): Historical validation results
         hypothesis_tests (List[HypothesisTestResult]): Completed hypothesis tests
         config (Dict): Advanced configuration parameters
-        
+
     Methods:
         add_node: Add node with enhanced metadata and role specification
         add_edge: Add directed edge with optional weight parameter
@@ -280,14 +285,14 @@ class AdvancedDAGValidator:
         calculate_acyclicity_pvalue_advanced: Advanced p-value calculation
         perform_sensitivity_analysis: Sensitivity analysis by edge perturbation
         calculate_bayesian_posterior: Bayesian posterior probability calculation
-        
+
     Example:
         >>> validator = AdvancedDAGValidator(GraphType.CAUSAL_DAG)
         >>> validator.add_node("X", role="intervention")
         >>> validator.add_node("Y", dependencies={"X"}, role="outcome")
         >>> result = validator.calculate_acyclicity_pvalue_advanced("test")
         >>> print(f"Acyclicity p-value: {result.p_value:.4f}")
-        
+
     Note:
         All statistical methods include proper multiple testing corrections and
         comprehensive sensitivity analysis for robust causal inference.
@@ -295,7 +300,7 @@ class AdvancedDAGValidator:
 
     def __init__(self, graph_type: GraphType = GraphType.CAUSAL_DAG):
         """Initialize the advanced DAG validator.
-        
+
         Args:
             graph_type: Type of graph structure for analysis (default: CAUSAL_DAG).
         """
@@ -307,21 +312,26 @@ class AdvancedDAGValidator:
 
         # Advanced configuration
         self.config = {
-            'min_subgraph_size': 3,
-            'max_subgraph_size': None,
-            'default_iterations': 10000,
-            'confidence_level': 0.95,
-            'power_threshold': 0.8,
-            'convergence_threshold': 1e-4,
-            'max_computation_time': 3600,  # seconds
-            'parallel_processing': True,
-            'num_processes': mp.cpu_count()
+            "min_subgraph_size": 3,
+            "max_subgraph_size": None,
+            "default_iterations": 10000,
+            "confidence_level": 0.95,
+            "power_threshold": 0.8,
+            "convergence_threshold": 1e-4,
+            "max_computation_time": 3600,  # seconds
+            "parallel_processing": True,
+            "num_processes": mp.cpu_count(),
         }
 
-    def add_node(self, name: str, dependencies: Set[str] = None,
-                 role: str = "variable", metadata: Dict[str, Any] = None):
+    def add_node(
+        self,
+        name: str,
+        dependencies: Set[str] = None,
+        role: str = "variable",
+        metadata: Dict[str, Any] = None,
+    ):
         """Add a node with enhanced metadata and role specification.
-        
+
         Args:
             name (str): Unique identifier for the node.
             dependencies (Set[str], optional): Set of node names that this node depends on.
@@ -334,21 +344,18 @@ class AdvancedDAGValidator:
             metadata = {}
 
         self.graph_nodes[name] = AdvancedGraphNode(
-            name=name,
-            dependencies=dependencies,
-            role=role,
-            metadata=metadata
+            name=name, dependencies=dependencies, role=role, metadata=metadata
         )
 
     def add_edge(self, from_node: str, to_node: str, weight: float = 1.0):
         """Add a directed edge with optional weight parameter.
-        
+
         Args:
             from_node (str): Source node name.
             to_node (str): Target node name.
             weight (float): Edge weight for causal strength (default: 1.0).
             weight (float, optional): Edge weight for analysis. Defaults to 1.0.
-            
+
         Note:
             Automatically creates nodes if they don't exist. Edge weight is stored
             in the target node's metadata for later analysis.
@@ -366,7 +373,7 @@ class AdvancedDAGValidator:
 
     def add_causal_pathway(self, pathway: List[str], weights: List[float] = None):
         """Add an entire causal pathway with optional weights.
-        
+
         Args:
             pathway: Ordered list of node names forming a causal pathway.
             weights: Optional list of weights for each edge in the pathway.
@@ -380,11 +387,11 @@ class AdvancedDAGValidator:
 
     def _initialize_advanced_rng(self, plan_name: str, salt: str = "") -> int:
         """Initialize advanced RNG with configurable seeding strategy.
-        
+
         Args:
             plan_name: Name of the plan for deterministic seed generation.
             salt: Additional salt string for seed variation.
-            
+
         Returns:
             Generated seed value for reproducibility.
         """
@@ -396,13 +403,13 @@ class AdvancedDAGValidator:
     @staticmethod
     def _compute_graph_metrics(nodes: Dict[str, AdvancedGraphNode]) -> Dict[str, Any]:
         """Compute comprehensive graph metrics for topological analysis.
-        
+
         Calculates various graph-theoretic measures including connectivity,
         centrality, clustering, and path-based metrics using NetworkX.
-        
+
         Args:
             nodes: Dictionary of graph nodes to analyze.
-            
+
         Returns:
             Dictionary containing computed graph metrics, or error information
             if computation fails.
@@ -422,45 +429,55 @@ class AdvancedDAGValidator:
 
         try:
             # Basic metrics
-            metrics['num_nodes'] = G.number_of_nodes()
-            metrics['num_edges'] = G.number_of_edges()
-            metrics['density'] = nx.density(G)
+            metrics["num_nodes"] = G.number_of_nodes()
+            metrics["num_edges"] = G.number_of_edges()
+            metrics["density"] = nx.density(G)
 
             # Path-based metrics
             if nx.is_weakly_connected(G):
-                metrics['average_path_length'] = nx.average_shortest_path_length(G)
-                metrics['diameter'] = nx.diameter(G)
+                metrics["average_path_length"] = nx.average_shortest_path_length(
+                    G)
+                metrics["diameter"] = nx.diameter(G)
             else:
-                metrics['average_path_length'] = float('inf')
-                metrics['diameter'] = float('inf')
+                metrics["average_path_length"] = float("inf")
+                metrics["diameter"] = float("inf")
 
             # Centrality measures
-            metrics['degree_centrality'] = nx.degree_centrality(G)
-            metrics['betweenness_centrality'] = nx.betweenness_centrality(G)
-            metrics['closeness_centrality'] = nx.closeness_centrality(G)
+            metrics["degree_centrality"] = nx.degree_centrality(G)
+            metrics["betweenness_centrality"] = nx.betweenness_centrality(G)
+            metrics["closeness_centrality"] = nx.closeness_centrality(G)
 
             # Clustering and connectivity
-            metrics['clustering_coefficient'] = nx.average_clustering(G.to_undirected())
-            metrics['strongly_connected_components'] = list(nx.strongly_connected_components(G))
-            metrics['weakly_connected_components'] = list(nx.weakly_connected_components(G))
+            metrics["clustering_coefficient"] = nx.average_clustering(
+                G.to_undirected())
+            metrics["strongly_connected_components"] = list(
+                nx.strongly_connected_components(G)
+            )
+            metrics["weakly_connected_components"] = list(
+                nx.weakly_connected_components(G)
+            )
 
         except Exception as e:
             # Fallback metrics if networkx fails
-            metrics['error'] = str(e)
-            metrics['basic_connectivity'] = AdvancedDAGValidator._compute_basic_connectivity(nodes)
+            metrics["error"] = str(e)
+            metrics["basic_connectivity"] = (
+                AdvancedDAGValidator._compute_basic_connectivity(nodes)
+            )
 
         return metrics
 
     @staticmethod
-    def _compute_basic_connectivity(nodes: Dict[str, AdvancedGraphNode]) -> Dict[str, Any]:
+    def _compute_basic_connectivity(
+        nodes: Dict[str, AdvancedGraphNode],
+    ) -> Dict[str, Any]:
         """Fallback connectivity computation without networkx.
-        
+
         Implements basic graph connectivity analysis using breadth-first search
         and degree distribution calculation when NetworkX is unavailable.
-        
+
         Args:
             nodes: Dictionary of graph nodes to analyze.
-            
+
         Returns:
             Dictionary containing basic connectivity metrics.
         """
@@ -486,13 +503,15 @@ class AdvancedDAGValidator:
                     queue.append(neighbor)
 
         return {
-            'connected_nodes': len(visited),
-            'is_connected': len(visited) == len(nodes),
-            'in_degree_distribution': dict(Counter(in_degree.values()))
+            "connected_nodes": len(visited),
+            "is_connected": len(visited) == len(nodes),
+            "in_degree_distribution": dict(Counter(in_degree.values())),
         }
 
     @staticmethod
-    def _is_acyclic_advanced(nodes: Dict[str, AdvancedGraphNode]) -> Tuple[bool, Dict[str, Any]]:
+    def _is_acyclic_advanced(
+        nodes: Dict[str, AdvancedGraphNode],
+    ) -> Tuple[bool, Dict[str, Any]]:
         """Enhanced acyclicity check with detailed cycle information."""
         if not nodes:
             return True, {}
@@ -507,7 +526,8 @@ class AdvancedDAGValidator:
                     in_degree[node_name] += 1
 
         # Kahn's algorithm with cycle detection
-        queue = deque([name for name, degree in in_degree.items() if degree == 0])
+        queue = deque(
+            [name for name, degree in in_degree.items() if degree == 0])
         processed = 0
         topological_order = []
 
@@ -525,18 +545,19 @@ class AdvancedDAGValidator:
 
         # Cycle detection details
         cycle_info = {
-            'is_acyclic': is_acyclic,
-            'processed_nodes': processed,
-            'total_nodes': len(nodes),
-            'topological_order': topological_order if is_acyclic else [],
-            'cycle_exists': not is_acyclic,
-            'cycle_length': len(nodes) - processed if not is_acyclic else 0
+            "is_acyclic": is_acyclic,
+            "processed_nodes": processed,
+            "total_nodes": len(nodes),
+            "topological_order": topological_order if is_acyclic else [],
+            "cycle_exists": not is_acyclic,
+            "cycle_length": len(nodes) - processed if not is_acyclic else 0,
         }
 
         return is_acyclic, cycle_info
 
-    def _generate_stratified_subgraph(self, strategy: str = "random",
-                                      **kwargs) -> Dict[str, AdvancedGraphNode]:
+    def _generate_stratified_subgraph(
+        self, strategy: str = "random", **kwargs
+    ) -> Dict[str, AdvancedGraphNode]:
         """Generate subgraphs using different sampling strategies."""
         if not self.graph_nodes:
             return {}
@@ -554,7 +575,9 @@ class AdvancedDAGValidator:
         else:
             return self._generate_random_subgraph(**kwargs)
 
-    def _generate_random_subgraph(self, min_size: int = 3, max_size: int = None) -> Dict[str, AdvancedGraphNode]:
+    def _generate_random_subgraph(
+        self, min_size: int = 3, max_size: int = None
+    ) -> Dict[str, AdvancedGraphNode]:
         """Enhanced random subgraph generation with stratification."""
         if max_size is None:
             max_size = len(self.graph_nodes)
@@ -568,12 +591,14 @@ class AdvancedDAGValidator:
             min_size = max(min_size, 5)
 
         subgraph_size = self._rng.randint(min_size, max_size)
-        selected_nodes = self._rng.sample(list(self.graph_nodes.keys()), subgraph_size)
+        selected_nodes = self._rng.sample(
+            list(self.graph_nodes.keys()), subgraph_size)
 
         return self._create_subgraph_from_nodes(selected_nodes)
 
-    def _generate_degree_stratified_subgraph(self, all_nodes: List[str],
-                                             min_size: int = 3) -> Dict[str, AdvancedGraphNode]:
+    def _generate_degree_stratified_subgraph(
+        self, all_nodes: List[str], min_size: int = 3
+    ) -> Dict[str, AdvancedGraphNode]:
         """Generate subgraph stratified by node degree."""
         # Calculate degrees for stratification
         degrees = {}
@@ -582,46 +607,60 @@ class AdvancedDAGValidator:
             degrees[node_name] = len(node.dependencies)
 
         # Stratify nodes by degree
-        high_degree = [n for n, d in degrees.items() if d > np.median(list(degrees.values()))]
-        low_degree = [n for n, d in degrees.items() if d <= np.median(list(degrees.values()))]
+        high_degree = [
+            n for n, d in degrees.items() if d > np.median(list(degrees.values()))
+        ]
+        low_degree = [
+            n for n, d in degrees.items() if d <= np.median(list(degrees.values()))
+        ]
 
         # Sample proportionally from each stratum
         high_sample_size = max(1, min_size // 2)
         low_sample_size = min_size - high_sample_size
 
-        selected_high = self._rng.sample(high_degree, min(high_sample_size, len(high_degree)))
-        selected_low = self._rng.sample(low_degree, min(low_sample_size, len(low_degree)))
+        selected_high = self._rng.sample(
+            high_degree, min(high_sample_size, len(high_degree))
+        )
+        selected_low = self._rng.sample(
+            low_degree, min(low_sample_size, len(low_degree))
+        )
 
         selected_nodes = selected_high + selected_low
 
         # Add random nodes if needed
         if len(selected_nodes) < min_size:
             remaining_nodes = set(all_nodes) - set(selected_nodes)
-            additional = self._rng.sample(list(remaining_nodes), min_size - len(selected_nodes))
+            additional = self._rng.sample(
+                list(remaining_nodes), min_size - len(selected_nodes)
+            )
             selected_nodes.extend(additional)
 
         return self._create_subgraph_from_nodes(selected_nodes)
 
-    def _create_subgraph_from_nodes(self, selected_nodes: List[str]) -> Dict[str, AdvancedGraphNode]:
+    def _create_subgraph_from_nodes(
+        self, selected_nodes: List[str]
+    ) -> Dict[str, AdvancedGraphNode]:
         """Create subgraph from selected nodes with filtered dependencies."""
         subgraph = {}
         for node_name in selected_nodes:
             original_node = self.graph_nodes[node_name]
-            filtered_deps = original_node.dependencies.intersection(set(selected_nodes))
+            filtered_deps = original_node.dependencies.intersection(
+                set(selected_nodes))
 
             # Create enhanced node copy
             subgraph_node = AdvancedGraphNode(
                 name=node_name,
                 dependencies=filtered_deps,
                 metadata=original_node.metadata.copy(),
-                role=original_node.role
+                role=original_node.role,
             )
             subgraph[node_name] = subgraph_node
 
         return subgraph
 
-    def calculate_bayesian_posterior(self, prior: float = 0.5,
-                                     iterations: int = 1000) -> float:
+    def calculate_bayesian_posterior(
+        self, prior: float = 0.5, iterations: int = 1000
+    ) -> float:
         """Calculate Bayesian posterior probability of acyclicity."""
         if not self.graph_nodes:
             return 1.0
@@ -637,16 +676,17 @@ class AdvancedDAGValidator:
 
         # Bayesian update: P(Acyclic|Data) = P(Data|Acyclic) * P(Acyclic) / P(Data)
         posterior = (likelihood * prior) / (
-                likelihood * prior + (1 - likelihood) * (1 - prior)
+            likelihood * prior + (1 - likelihood) * (1 - prior)
         )
 
         return posterior
 
-    def perform_sensitivity_analysis(self, plan_name: str,
-                                     perturbation_level: float = 0.1,
-                                     iterations: int = 500) -> Dict[str, Any]:
+    def perform_sensitivity_analysis(
+        self, plan_name: str, perturbation_level: float = 0.1, iterations: int = 500
+    ) -> Dict[str, Any]:
         """Perform sensitivity analysis by perturbing edges."""
-        base_result = self.calculate_acyclicity_pvalue_advanced(plan_name, iterations)
+        base_result = self.calculate_acyclicity_pvalue_advanced(
+            plan_name, iterations)
         base_p_value = base_result.p_value
 
         # Edge removal sensitivity
@@ -655,7 +695,7 @@ class AdvancedDAGValidator:
 
         for edge in original_edges:
             # Temporarily remove edge
-            from_node, to_node = edge.split('->')
+            from_node, to_node = edge.split("->")
             original_deps = self.graph_nodes[to_node].dependencies.copy()
 
             if from_node in self.graph_nodes[to_node].dependencies:
@@ -672,32 +712,34 @@ class AdvancedDAGValidator:
                 self.graph_nodes[to_node].dependencies = original_deps
 
         return {
-            'base_p_value': base_p_value,
-            'edge_sensitivity': edge_sensitivity,
-            'average_sensitivity': np.mean(list(edge_sensitivity.values())),
-            'max_sensitivity': max(edge_sensitivity.values()) if edge_sensitivity else 0
+            "base_p_value": base_p_value,
+            "edge_sensitivity": edge_sensitivity,
+            "average_sensitivity": np.mean(list(edge_sensitivity.values())),
+            "max_sensitivity": (
+                max(edge_sensitivity.values()) if edge_sensitivity else 0
+            ),
         }
 
     def calculate_acyclicity_pvalue_advanced(
-            self,
-            plan_name: str,
-            iterations: int = None,
-            min_subgraph_size: int = None,
-            max_subgraph_size: int = None,
-            confidence_level: float = None,
-            test_strategy: str = "comprehensive"
+        self,
+        plan_name: str,
+        iterations: int = None,
+        min_subgraph_size: int = None,
+        max_subgraph_size: int = None,
+        confidence_level: float = None,
+        test_strategy: str = "comprehensive",
     ) -> MonteCarloAdvancedResult:
         """
         Advanced p-value calculation with multiple statistical approaches.
         """
         if iterations is None:
-            iterations = self.config['default_iterations']
+            iterations = self.config["default_iterations"]
         if min_subgraph_size is None:
-            min_subgraph_size = self.config['min_subgraph_size']
+            min_subgraph_size = self.config["min_subgraph_size"]
         if max_subgraph_size is None:
-            max_subgraph_size = self.config['max_subgraph_size']
+            max_subgraph_size = self.config["max_subgraph_size"]
         if confidence_level is None:
-            confidence_level = self.config['confidence_level']
+            confidence_level = self.config["confidence_level"]
 
         start_time = time.time()
         seed = self._initialize_advanced_rng(plan_name)
@@ -707,28 +749,40 @@ class AdvancedDAGValidator:
             return self._create_empty_result(plan_name, seed, timestamp)
 
         # Parallel processing for large iterations
-        if iterations > 1000 and self.config['parallel_processing']:
-            results = self._run_parallel_monte_carlo(iterations, min_subgraph_size, max_subgraph_size)
+        if iterations > 1000 and self.config["parallel_processing"]:
+            results = self._run_parallel_monte_carlo(
+                iterations, min_subgraph_size, max_subgraph_size
+            )
         else:
-            results = self._run_sequential_monte_carlo(iterations, min_subgraph_size, max_subgraph_size)
+            results = self._run_sequential_monte_carlo(
+                iterations, min_subgraph_size, max_subgraph_size
+            )
 
-        acyclic_count = results['acyclic_count']
-        subgraph_sizes = results['subgraph_sizes']
-        graph_metrics = results['graph_metrics']
+        acyclic_count = results["acyclic_count"]
+        subgraph_sizes = results["subgraph_sizes"]
+        graph_metrics = results["graph_metrics"]
 
         # Calculate p-value with confidence interval
         p_value = acyclic_count / iterations if iterations > 0 else 1.0
-        ci = AdvancedDAGValidator._calculate_confidence_interval(acyclic_count, iterations, confidence_level)
+        ci = AdvancedDAGValidator._calculate_confidence_interval(
+            acyclic_count, iterations, confidence_level
+        )
 
         # Bayesian posterior
-        posterior = self.calculate_bayesian_posterior(iterations=min(iterations, 1000))
+        posterior = self.calculate_bayesian_posterior(
+            iterations=min(iterations, 1000))
 
         # Effect size and power
-        effect_size = AdvancedDAGValidator._calculate_effect_size(acyclic_count, iterations)
-        statistical_power = self._calculate_statistical_power(acyclic_count, iterations)
+        effect_size = AdvancedDAGValidator._calculate_effect_size(
+            acyclic_count, iterations
+        )
+        statistical_power = self._calculate_statistical_power(
+            acyclic_count, iterations)
 
         # Sensitivity analysis
-        sensitivity = self.perform_sensitivity_analysis(plan_name, iterations=min(iterations, 200))
+        sensitivity = self.perform_sensitivity_analysis(
+            plan_name, iterations=min(iterations, 200)
+        )
 
         computation_time = time.time() - start_time
 
@@ -744,63 +798,76 @@ class AdvancedDAGValidator:
             confidence_interval=ci,
             effect_size=effect_size,
             statistical_power=statistical_power,
-            average_path_length=graph_metrics.get('average_path_length', 0),
-            clustering_coefficient=graph_metrics.get('clustering_coefficient', 0),
-            degree_distribution=graph_metrics.get('degree_distribution', {}),
-            connectivity_ratio=graph_metrics.get('connectivity_ratio', 0),
-            edge_sensitivity=sensitivity['edge_sensitivity'],
+            average_path_length=graph_metrics.get("average_path_length", 0),
+            clustering_coefficient=graph_metrics.get(
+                "clustering_coefficient", 0),
+            degree_distribution=graph_metrics.get("degree_distribution", {}),
+            connectivity_ratio=graph_metrics.get("connectivity_ratio", 0),
+            edge_sensitivity=sensitivity["edge_sensitivity"],
             node_importance=self._calculate_node_importance(),
             robustness_score=self._calculate_robustness_score(sensitivity),
             reproducible=self.verify_advanced_reproducibility(plan_name),
-            convergence_achieved=self._check_convergence(acyclic_count, iterations),
-            adequate_power=statistical_power >= self.config['power_threshold'],
+            convergence_achieved=self._check_convergence(
+                acyclic_count, iterations),
+            adequate_power=statistical_power >= self.config["power_threshold"],
             computation_time=computation_time,
             graph_statistics=self.get_advanced_graph_stats(),
             test_parameters={
-                'iterations': iterations,
-                'min_subgraph_size': min_subgraph_size,
-                'max_subgraph_size': max_subgraph_size,
-                'confidence_level': confidence_level,
-                'strategy': test_strategy
-            }
+                "iterations": iterations,
+                "min_subgraph_size": min_subgraph_size,
+                "max_subgraph_size": max_subgraph_size,
+                "confidence_level": confidence_level,
+                "strategy": test_strategy,
+            },
         )
 
-    def _run_parallel_monte_carlo(self, iterations: int, min_size: int, max_size: int) -> Dict[str, Any]:
+    def _run_parallel_monte_carlo(
+        self, iterations: int, min_size: int, max_size: int
+    ) -> Dict[str, Any]:
         """Run Monte Carlo simulation in parallel."""
-        chunk_size = iterations // self.config['num_processes']
-        chunks = [chunk_size] * self.config['num_processes']
-        chunks[-1] += iterations % self.config['num_processes']  # Adjust last chunk
+        chunk_size = iterations // self.config["num_processes"]
+        chunks = [chunk_size] * self.config["num_processes"]
+        # Adjust last chunk
+        chunks[-1] += iterations % self.config["num_processes"]
 
-        with ProcessPoolExecutor(max_workers=self.config['num_processes']) as executor:
+        with ProcessPoolExecutor(max_workers=self.config["num_processes"]) as executor:
             futures = [
-                executor.submit(self._monte_carlo_chunk, chunk, min_size, max_size)
+                executor.submit(self._monte_carlo_chunk,
+                                chunk, min_size, max_size)
                 for chunk in chunks
             ]
 
             results = [future.result() for future in futures]
 
         # Combine results
-        total_acyclic = sum(r['acyclic_count'] for r in results)
-        all_sizes = [size for r in results for size in r['subgraph_sizes']]
-        combined_metrics = self._combine_graph_metrics([r['graph_metrics'] for r in results])
+        total_acyclic = sum(r["acyclic_count"] for r in results)
+        all_sizes = [size for r in results for size in r["subgraph_sizes"]]
+        combined_metrics = self._combine_graph_metrics(
+            [r["graph_metrics"] for r in results]
+        )
 
         return {
-            'acyclic_count': total_acyclic,
-            'subgraph_sizes': all_sizes,
-            'graph_metrics': combined_metrics
+            "acyclic_count": total_acyclic,
+            "subgraph_sizes": all_sizes,
+            "graph_metrics": combined_metrics,
         }
 
-    def _monte_carlo_chunk(self, chunk_iterations: int, min_size: int, max_size: int) -> Dict[str, Any]:
+    def _monte_carlo_chunk(
+        self, chunk_iterations: int, min_size: int, max_size: int
+    ) -> Dict[str, Any]:
         """Process a chunk of Monte Carlo iterations."""
         acyclic_count = 0
         subgraph_sizes = []
         graph_metrics = []
 
         for _ in range(chunk_iterations):
-            subgraph = self._generate_stratified_subgraph("random", min_size=min_size, max_size=max_size)
+            subgraph = self._generate_stratified_subgraph(
+                "random", min_size=min_size, max_size=max_size
+            )
             subgraph_sizes.append(len(subgraph))
 
-            is_acyclic, cycle_info = AdvancedDAGValidator._is_acyclic_advanced(subgraph)
+            is_acyclic, cycle_info = AdvancedDAGValidator._is_acyclic_advanced(
+                subgraph)
             if is_acyclic:
                 acyclic_count += 1
 
@@ -812,14 +879,15 @@ class AdvancedDAGValidator:
         aggregated_metrics = self._aggregate_metrics(graph_metrics)
 
         return {
-            'acyclic_count': acyclic_count,
-            'subgraph_sizes': subgraph_sizes,
-            'graph_metrics': aggregated_metrics
+            "acyclic_count": acyclic_count,
+            "subgraph_sizes": subgraph_sizes,
+            "graph_metrics": aggregated_metrics,
         }
 
     @staticmethod
-    def _calculate_confidence_interval(successes: int, trials: int,
-                                       confidence: float) -> Tuple[float, float]:
+    def _calculate_confidence_interval(
+        successes: int, trials: int, confidence: float
+    ) -> Tuple[float, float]:
         """Calculate Wilson score interval for binomial proportion."""
         if trials == 0:
             return (0.0, 1.0)
@@ -827,9 +895,13 @@ class AdvancedDAGValidator:
         z = stats.norm.ppf(1 - (1 - confidence) / 2)
         p_hat = successes / trials
 
-        denominator = 1 + z ** 2 / trials
-        centre = (p_hat + z ** 2 / (2 * trials)) / denominator
-        half_width = z * np.sqrt(p_hat * (1 - p_hat) / trials + z ** 2 / (4 * trials ** 2)) / denominator
+        denominator = 1 + z**2 / trials
+        centre = (p_hat + z**2 / (2 * trials)) / denominator
+        half_width = (
+            z
+            * np.sqrt(p_hat * (1 - p_hat) / trials + z**2 / (4 * trials**2))
+            / denominator
+        )
 
         lower = max(0, centre - half_width)
         upper = min(1, centre + half_width)
@@ -847,21 +919,25 @@ class AdvancedDAGValidator:
         return 2 * (np.arcsin(np.sqrt(p)) - np.arcsin(np.sqrt(0.5)))
 
     @staticmethod
-    def _calculate_statistical_power(successes: int, trials: int,
-                                     alpha: float = 0.05) -> float:
+    def _calculate_statistical_power(
+        successes: int, trials: int, alpha: float = 0.05
+    ) -> float:
         """Calculate statistical power for the test."""
         if trials == 0:
             return 0.0
 
         p = successes / trials
         # Power for one-sample proportion test against 0.5
-        effect_size = AdvancedDAGValidator._calculate_effect_size(successes, trials)
-        power = stats.norm.sf(stats.norm.ppf(1 - alpha) - effect_size * np.sqrt(trials))
+        effect_size = AdvancedDAGValidator._calculate_effect_size(
+            successes, trials)
+        power = stats.norm.sf(stats.norm.ppf(
+            1 - alpha) - effect_size * np.sqrt(trials))
 
         return power
 
-    def verify_advanced_reproducibility(self, plan_name: str,
-                                        test_iterations: int = 100) -> bool:
+    def verify_advanced_reproducibility(
+        self, plan_name: str, test_iterations: int = 100
+    ) -> bool:
         """Enhanced reproducibility verification with multiple tests."""
         try:
             # Test multiple times with different salts
@@ -895,15 +971,20 @@ class AdvancedDAGValidator:
     def _get_basic_graph_stats(self) -> Dict[str, Any]:
         """Get basic graph statistics."""
         total_nodes = len(self.graph_nodes)
-        total_edges = sum(len(node.dependencies) for node in self.graph_nodes.values())
+        total_edges = sum(len(node.dependencies)
+                          for node in self.graph_nodes.values())
 
         return {
             "total_nodes": total_nodes,
             "total_edges": total_edges,
-            "graph_density": total_edges / (total_nodes * (total_nodes - 1)) if total_nodes > 1 else 0,
+            "graph_density": (
+                total_edges / (total_nodes * (total_nodes - 1))
+                if total_nodes > 1
+                else 0
+            ),
             "average_degree": total_edges / total_nodes if total_nodes > 0 else 0,
             "max_possible_edges": total_nodes * (total_nodes - 1),
-            "edge_node_ratio": total_edges / total_nodes if total_nodes > 0 else 0
+            "edge_node_ratio": total_edges / total_nodes if total_nodes > 0 else 0,
         }
 
     def _get_topological_stats(self) -> Dict[str, Any]:
@@ -942,7 +1023,9 @@ class AdvancedDAGValidator:
             "role_distribution": role_counts,
             "average_path_length": np.mean(path_lengths) if path_lengths else 0,
             "max_path_length": max(path_lengths) if path_lengths else 0,
-            "root_nodes": len([n for n in self.graph_nodes.values() if not n.dependencies]),
+            "root_nodes": len(
+                [n for n in self.graph_nodes.values() if not n.dependencies]
+            ),
             "leaf_nodes": self._count_leaf_nodes(),
         }
 
@@ -970,8 +1053,11 @@ class AdvancedDAGValidator:
         for node_name in self.graph_nodes:
             # Simple importance based on degree and role
             node = self.graph_nodes[node_name]
-            degree_importance = len(node.dependencies) / max(1, len(self.graph_nodes) - 1)
-            role_importance = 1.0 if node.role in ["intervention", "outcome"] else 0.5
+            degree_importance = len(node.dependencies) / max(
+                1, len(self.graph_nodes) - 1
+            )
+            role_importance = 1.0 if node.role in [
+                "intervention", "outcome"] else 0.5
             importance[node_name] = (degree_importance + role_importance) / 2
 
         return importance
@@ -979,8 +1065,8 @@ class AdvancedDAGValidator:
     @staticmethod
     def _calculate_robustness_score(sensitivity_results: Dict[str, Any]) -> float:
         """Calculate overall robustness score from sensitivity analysis."""
-        avg_sensitivity = sensitivity_results.get('average_sensitivity', 0)
-        max_sensitivity = sensitivity_results.get('max_sensitivity', 0)
+        avg_sensitivity = sensitivity_results.get("average_sensitivity", 0)
+        max_sensitivity = sensitivity_results.get("max_sensitivity", 0)
 
         # Convert to robustness (inverse of sensitivity)
         robustness = 1.0 / (1.0 + avg_sensitivity + max_sensitivity)
@@ -993,11 +1079,16 @@ class AdvancedDAGValidator:
 
         # Simple convergence check based on recent stability
         # For sophisticated implementation, would track running estimates
-        expected_variance = (acyclic_count / iterations) * (1 - acyclic_count / iterations) / iterations
-        return expected_variance < self.config['convergence_threshold']
+        expected_variance = (
+            (acyclic_count / iterations) *
+            (1 - acyclic_count / iterations) / iterations
+        )
+        return expected_variance < self.config["convergence_threshold"]
 
     @staticmethod
-    def _create_empty_result(plan_name: str, seed: int, timestamp: str) -> MonteCarloAdvancedResult:
+    def _create_empty_result(
+        plan_name: str, seed: int, timestamp: str
+    ) -> MonteCarloAdvancedResult:
         """Create empty result for empty graph."""
         return MonteCarloAdvancedResult(
             plan_name=plan_name,
@@ -1023,7 +1114,7 @@ class AdvancedDAGValidator:
             adequate_power=False,
             computation_time=0.0,
             graph_statistics={},
-            test_parameters={}
+            test_parameters={},
         )
 
     @staticmethod
@@ -1055,8 +1146,12 @@ class AdvancedDAGValidator:
 
         return combined
 
-    def export_results(self, result: MonteCarloAdvancedResult,
-                       format: str = "json", filename: str = None) -> str:
+    def export_results(
+        self,
+        result: MonteCarloAdvancedResult,
+        format: str = "json",
+        filename: str = None,
+    ) -> str:
         """Export results in various formats for reporting."""
         if filename is None:
             filename = f"dag_validation_{result.plan_name}_{result.timestamp}"
@@ -1074,25 +1169,25 @@ class AdvancedDAGValidator:
     def _export_json(result: MonteCarloAdvancedResult, filename: str) -> str:
         """Export results as JSON."""
         data = {
-            'validation_results': {
-                'plan_name': result.plan_name,
-                'timestamp': result.timestamp,
-                'p_value': result.p_value,
-                'confidence_interval': result.confidence_interval,
-                'bayesian_posterior': result.bayesian_posterior,
-                'statistical_power': result.statistical_power,
-                'graph_statistics': result.graph_statistics,
-                'computation_time': result.computation_time
+            "validation_results": {
+                "plan_name": result.plan_name,
+                "timestamp": result.timestamp,
+                "p_value": result.p_value,
+                "confidence_interval": result.confidence_interval,
+                "bayesian_posterior": result.bayesian_posterior,
+                "statistical_power": result.statistical_power,
+                "graph_statistics": result.graph_statistics,
+                "computation_time": result.computation_time,
             },
-            'metadata': {
-                'total_iterations': result.total_iterations,
-                'seed': result.seed,
-                'reproducible': result.reproducible
-            }
+            "metadata": {
+                "total_iterations": result.total_iterations,
+                "seed": result.seed,
+                "reproducible": result.reproducible,
+            },
         }
 
         filepath = f"{filename}.json"
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             safe_json_dump(data, f)
 
         return filepath
@@ -1124,7 +1219,7 @@ class AdvancedDAGValidator:
             <div class="results">
                 <h2>Statistical Results</h2>
                 <div class="metric">
-                    <p>P-value: <span class="{'significant' if result.p_value < 0.05 else 'not-significant'}">{result.p_value:.6f}</span></p>
+                    <p>P-value: <span class="{"significant" if result.p_value < 0.05 else "not-significant"}">{result.p_value:.6f}</span></p>
                     <p>Bayesian Posterior: {result.bayesian_posterior:.4f}</p>
                     <p>Statistical Power: {result.statistical_power:.4f}</p>
                     <p>Confidence Interval: [{result.confidence_interval[0]:.4f}, {result.confidence_interval[1]:.4f}]</p>
@@ -1138,7 +1233,7 @@ class AdvancedDAGValidator:
         """
 
         filepath = f"{filename}.html"
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             f.write(html_content)
 
         return filepath
@@ -1180,7 +1275,7 @@ class AdvancedDAGValidator:
         """
 
         filepath = f"{filename}.tex"
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             f.write(latex_content)
 
         return filepath
@@ -1218,7 +1313,7 @@ class AdvancedDAGValidator:
         """
 
         filepath = f"{filename}.txt"
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             f.write(text_content)
 
         return filepath
@@ -1230,16 +1325,44 @@ def create_complex_causal_graph() -> AdvancedDAGValidator:
 
     # Define nodes with roles and metadata
     nodes_config = [
-        ("recursos_financieros", "intervention", {"budget": 100000, "currency": "USD"}),
-        ("capacitacion_personal", "intervention", {"duration": 6, "format": "workshop"}),
-        ("infraestructura", "intervention", {"type": "physical", "scale": "large"}),
-        ("programas_intervencion", "mediator", {"intensity": "high", "frequency": "weekly"}),
-        ("participacion_comunidad", "mediator", {"engagement": "active", "reach": 500}),
-        ("cambio_comportamiento", "outcome", {"measurement": "survey", "validity": 0.85}),
-        ("mejora_indicadores", "outcome", {"indicators": ["health", "education"], "trend": "positive"}),
-        ("impacto_social", "outcome", {"sustainability": "long_term", "scope": "community"}),
-        ("contexto_social", "covariate", {"stability": "medium", "influence": "moderate"}),
-        ("factores_externos", "covariate", {"control": "low", "variability": "high"})
+        ("recursos_financieros", "intervention",
+         {"budget": 100000, "currency": "USD"}),
+        (
+            "capacitacion_personal",
+            "intervention",
+            {"duration": 6, "format": "workshop"},
+        ),
+        ("infraestructura", "intervention", {
+         "type": "physical", "scale": "large"}),
+        (
+            "programas_intervencion",
+            "mediator",
+            {"intensity": "high", "frequency": "weekly"},
+        ),
+        ("participacion_comunidad", "mediator", {
+         "engagement": "active", "reach": 500}),
+        (
+            "cambio_comportamiento",
+            "outcome",
+            {"measurement": "survey", "validity": 0.85},
+        ),
+        (
+            "mejora_indicadores",
+            "outcome",
+            {"indicators": ["health", "education"], "trend": "positive"},
+        ),
+        (
+            "impacto_social",
+            "outcome",
+            {"sustainability": "long_term", "scope": "community"},
+        ),
+        (
+            "contexto_social",
+            "covariate",
+            {"stability": "medium", "influence": "moderate"},
+        ),
+        ("factores_externos", "covariate", {
+         "control": "low", "variability": "high"}),
     ]
 
     for name, role, metadata in nodes_config:
@@ -1256,7 +1379,7 @@ def create_complex_causal_graph() -> AdvancedDAGValidator:
         (["cambio_comportamiento", "mejora_indicadores"], [0.8]),
         (["mejora_indicadores", "impacto_social"], [0.9]),
         (["contexto_social", "participacion_comunidad"], [0.4]),
-        (["factores_externos", "impacto_social"], [0.3])
+        (["factores_externos", "impacto_social"], [0.3]),
     ]
 
     for pathway, weights in pathways:
@@ -1276,8 +1399,9 @@ class DAGValidationSuite:
         """Add a validator to the suite."""
         self.validators[name] = validator
 
-    def run_comprehensive_validation(self, plan_name: str,
-                                     iterations: int = 10000) -> Dict[str, MonteCarloAdvancedResult]:
+    def run_comprehensive_validation(
+        self, plan_name: str, iterations: int = 10000
+    ) -> Dict[str, MonteCarloAdvancedResult]:
         """Run validation across all registered validators."""
         results = {}
 
@@ -1304,11 +1428,11 @@ class DAGValidationSuite:
 
         for name, result in results.items():
             comparison[name] = {
-                'p_value': result.p_value,
-                'bayesian_posterior': result.bayesian_posterior,
-                'statistical_power': result.statistical_power,
-                'robustness_score': result.robustness_score,
-                'computation_time': result.computation_time
+                "p_value": result.p_value,
+                "bayesian_posterior": result.bayesian_posterior,
+                "statistical_power": result.statistical_power,
+                "robustness_score": result.robustness_score,
+                "computation_time": result.computation_time,
             }
 
         return comparison
@@ -1334,16 +1458,16 @@ def demonstrate_advanced_features():
     print(f"RUNNING ADVANCED VALIDATION FOR: {plan_name}")
 
     result = validator.calculate_acyclicity_pvalue_advanced(
-        plan_name,
-        iterations=5000,
-        test_strategy="comprehensive"
+        plan_name, iterations=5000, test_strategy="comprehensive"
     )
 
     # Display key results
     print("\nKEY RESULTS:")
     print(f"P-value: {result.p_value:.6f}")
     print(f"Bayesian Posterior: {result.bayesian_posterior:.4f}")
-    print(f"95% Confidence Interval: [{result.confidence_interval[0]:.4f}, {result.confidence_interval[1]:.4f}]")
+    print(
+        f"95% Confidence Interval: [{result.confidence_interval[0]:.4f}, {result.confidence_interval[1]:.4f}]"
+    )
     print(f"Statistical Power: {result.statistical_power:.4f}")
     print(f"Robustness Score: {result.robustness_score:.4f}")
     print(f"Computation Time: {result.computation_time:.2f} seconds")
@@ -1361,7 +1485,8 @@ def demonstrate_advanced_features():
     print(f"\nSENSITIVITY ANALYSIS:")
     print(f"Average Sensitivity: {sensitivity['average_sensitivity']:.4f}")
     print(
-        f"Most Sensitive Edge: {max(sensitivity['edge_sensitivity'].items(), key=lambda x: x[1]) if sensitivity['edge_sensitivity'] else 'N/A'}")
+        f"Most Sensitive Edge: {max(sensitivity['edge_sensitivity'].items(), key=lambda x: x[1]) if sensitivity['edge_sensitivity'] else 'N/A'}"
+    )
 
     return validator, result
 

--- a/device_config.py
+++ b/device_config.py
@@ -15,50 +15,52 @@ logger = logging.getLogger(__name__)
 
 class DeviceConfig:
     """Centralized PyTorch device configuration and management."""
-    
+
     def __init__(self, device_str: Optional[str] = None):
         """
         Initialize device configuration.
-        
+
         Args:
             device_str: Device specification like 'cpu', 'cuda', 'cuda:0', etc.
                        If None, auto-detects best available device.
         """
         self.device = self._configure_device(device_str)
         self._setup_thread_configuration()
-        
+
         logger.info(f"PyTorch device configured: {self.device}")
         logger.info(f"CUDA available: {torch.cuda.is_available()}")
         if torch.cuda.is_available():
             logger.info(f"CUDA device count: {torch.cuda.device_count()}")
-    
+
     def _configure_device(self, device_str: Optional[str]) -> torch.device:
         """Configure and validate the PyTorch device."""
         if device_str is None:
             # Auto-detect best available device
             if torch.cuda.is_available():
-                device = torch.device('cuda')
+                device = torch.device("cuda")
                 logger.info("Auto-detected device: CUDA")
             else:
-                device = torch.device('cpu')
+                device = torch.device("cpu")
                 logger.info("Auto-detected device: CPU")
         else:
             device = self._parse_and_validate_device(device_str)
-        
+
         return device
-    
+
     @staticmethod
     def _parse_and_validate_device(device_str: str) -> torch.device:
         """Parse and validate the device string."""
         try:
             device = torch.device(device_str)
-            
+
             # Validate CUDA devices
-            if device.type == 'cuda':
+            if device.type == "cuda":
                 if not torch.cuda.is_available():
-                    logger.warning(f"CUDA requested ({device_str}) but not available. Falling back to CPU.")
-                    return torch.device('cpu')
-                
+                    logger.warning(
+                        f"CUDA requested ({device_str}) but not available. Falling back to CPU."
+                    )
+                    return torch.device("cpu")
+
                 # Check specific CUDA device index
                 if device.index is not None:
                     if device.index >= torch.cuda.device_count():
@@ -66,77 +68,91 @@ class DeviceConfig:
                             f"CUDA device {device.index} not available "
                             f"(only {torch.cuda.device_count()} devices). Falling back to CPU."
                         )
-                        return torch.device('cpu')
-                    
+                        return torch.device("cpu")
+
                     # Test device accessibility
                     try:
                         torch.zeros(1, device=device)
                         logger.info(f"Validated CUDA device: {device}")
                     except RuntimeError as e:
-                        logger.warning(f"CUDA device {device} not accessible: {e}. Falling back to CPU.")
-                        return torch.device('cpu')
+                        logger.warning(
+                            f"CUDA device {device} not accessible: {e}. Falling back to CPU."
+                        )
+                        return torch.device("cpu")
                 else:
                     # Default to cuda:0 if just 'cuda' specified
-                    device = torch.device('cuda:0')
+                    device = torch.device("cuda:0")
                     try:
                         torch.zeros(1, device=device)
                         logger.info(f"Validated CUDA device: {device}")
                     except RuntimeError as e:
-                        logger.warning(f"Default CUDA device not accessible: {e}. Falling back to CPU.")
-                        return torch.device('cpu')
-            
+                        logger.warning(
+                            f"Default CUDA device not accessible: {e}. Falling back to CPU."
+                        )
+                        return torch.device("cpu")
+
             return device
-            
+
         except RuntimeError as e:
             logger.error(f"Invalid device specification '{device_str}': {e}")
             logger.info("Falling back to CPU")
-            return torch.device('cpu')
-    
+            return torch.device("cpu")
+
     def _setup_thread_configuration(self):
         """Configure PyTorch threading based on device selection."""
-        if self.device.type == 'cuda':
+        if self.device.type == "cuda":
             # Set single thread when using CUDA to prevent oversubscription
             torch.set_num_threads(1)
-            logger.info("Set PyTorch to single thread mode for CUDA device to prevent thread oversubscription")
+            logger.info(
+                "Set PyTorch to single thread mode for CUDA device to prevent thread oversubscription"
+            )
         else:
             # For CPU, let PyTorch use default threading
-            logger.info(f"Using PyTorch default threading for CPU (threads: {torch.get_num_threads()})")
-    
+            logger.info(
+                f"Using PyTorch default threading for CPU (threads: {torch.get_num_threads()})"
+            )
+
     def get_device(self) -> torch.device:
         """Get the configured device."""
         return self.device
-    
+
     def to_device(self, tensor_or_model):
         """Move tensor or model to the configured device."""
         return tensor_or_model.to(self.device)
-    
+
     def get_device_info(self) -> dict:
         """Get device information for logging/debugging."""
         info = {
-            'device_str': str(self.device),
-            'device_type': self.device.type,
-            'pytorch_version': torch.__version__,
-            'cuda_available': torch.cuda.is_available(),
-            'num_threads': torch.get_num_threads()
+            "device_str": str(self.device),
+            "device_type": self.device.type,
+            "pytorch_version": torch.__version__,
+            "cuda_available": torch.cuda.is_available(),
+            "num_threads": torch.get_num_threads(),
         }
-        
+
         if torch.cuda.is_available():
-            info.update({
-                'cuda_device_count': torch.cuda.device_count(),
-                'cuda_version': torch.version.cuda,
-                'cudnn_version': torch.backends.cudnn.version()
-            })
-            
-            if self.device.type == 'cuda':
+            info.update(
+                {
+                    "cuda_device_count": torch.cuda.device_count(),
+                    "cuda_version": torch.version.cuda,
+                    "cudnn_version": torch.backends.cudnn.version(),
+                }
+            )
+
+            if self.device.type == "cuda":
                 device_idx = self.device.index or 0
                 if device_idx < torch.cuda.device_count():
-                    info.update({
-                        'device_name': torch.cuda.get_device_name(device_idx),
-                        'device_capability': torch.cuda.get_device_capability(device_idx),
-                        'memory_allocated': torch.cuda.memory_allocated(device_idx),
-                        'memory_cached': torch.cuda.memory_reserved(device_idx)
-                    })
-        
+                    info.update(
+                        {
+                            "device_name": torch.cuda.get_device_name(device_idx),
+                            "device_capability": torch.cuda.get_device_capability(
+                                device_idx
+                            ),
+                            "memory_allocated": torch.cuda.memory_allocated(device_idx),
+                            "memory_cached": torch.cuda.memory_reserved(device_idx),
+                        }
+                    )
+
         return info
 
 
@@ -172,14 +188,14 @@ def to_device(tensor_or_model):
 def add_device_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add device-related command line arguments to an ArgumentParser."""
     parser.add_argument(
-        '--device',
+        "--device",
         type=str,
         default=None,
-        help='PyTorch device to use (e.g., "cpu", "cuda", "cuda:0"). Auto-detects if not specified.'
+        help='PyTorch device to use (e.g., "cpu", "cuda", "cuda:0"). Auto-detects if not specified.',
     )
     return parser
 
 
 def configure_device_from_args(args) -> DeviceConfig:
     """Configure device from parsed command line arguments."""
-    return initialize_device_config(getattr(args, 'device', None))
+    return initialize_device_config(getattr(args, "device", None))

--- a/feasibility_scorer.py
+++ b/feasibility_scorer.py
@@ -42,29 +42,31 @@ Note:
     is designed for production use with comprehensive error handling.
 """
 
+import argparse
+import datetime
+import gzip
+import json
+import logging
 import os
 import re
-import datetime
 import time
 import unicodedata
 import uuid
-import logging
-import argparse
-import json
-import gzip
-from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 try:
     import pandas as pd
+
     PANDAS_AVAILABLE = True
 except ImportError:
     PANDAS_AVAILABLE = False
 
 try:
     from joblib import Parallel, delayed
+
     JOBLIB_AVAILABLE = True
 except ImportError:
     JOBLIB_AVAILABLE = False
@@ -73,17 +75,18 @@ except ImportError:
 class ComponentType(Enum):
     """
     Enumeration of detectable component types in policy indicators.
-    
+
     Defines the key components that determine indicator quality and feasibility
     for effective policy evaluation and monitoring.
-    
+
     Attributes:
         BASELINE: Baseline or current state values
-        TARGET: Goals, targets, or desired outcomes  
+        TARGET: Goals, targets, or desired outcomes
         TIME_HORIZON: Temporal frameworks and deadlines
         NUMERICAL: Quantitative values and metrics
         DATE: Specific dates and temporal references
     """
+
     BASELINE = "baseline"
     TARGET = "target"
     TIME_HORIZON = "time_horizon"
@@ -95,13 +98,14 @@ class ComponentType(Enum):
 class DetectionResult:
     """
     Individual component detection result with position and confidence.
-    
+
     Args:
         component_type (ComponentType): Type of component detected
         matched_text (str): Actual text that matched the pattern
         confidence (float): Confidence level of the match (0.0-1.0)
         position (int): Character position where match was found
     """
+
     component_type: ComponentType
     matched_text: str
     confidence: float
@@ -112,7 +116,7 @@ class DetectionResult:
 class IndicatorScore:
     """
     Comprehensive indicator quality score with detailed analysis.
-    
+
     Args:
         feasibility_score (float): Overall feasibility score (0.0-1.0)
         components_detected (List[ComponentType]): List of detected component types
@@ -121,6 +125,7 @@ class IndicatorScore:
         has_quantitative_target (bool): Whether quantitative target was detected
         quality_tier (str): Quality classification ("high", "medium", "low", "poor", "insufficient")
     """
+
     feasibility_score: float
     components_detected: List[ComponentType]
     detailed_matches: List[DetectionResult]
@@ -133,7 +138,7 @@ class IndicatorScore:
 class BatchScoreResult:
     """
     Batch processing results with comprehensive performance metrics.
-    
+
     Args:
         scores (List[IndicatorScore]): Individual indicator scores
         total_indicators (int): Total number of indicators processed
@@ -141,6 +146,7 @@ class BatchScoreResult:
         duracion_segundos (float): Execution duration in seconds
         planes_por_minuto (float): Processing rate (indicators per minute)
     """
+
     scores: List[IndicatorScore]
     total_indicators: int
     execution_time: str
@@ -151,35 +157,35 @@ class BatchScoreResult:
 class FeasibilityScorer:
     """
     Advanced feasibility scorer for policy indicator quality assessment.
-    
+
     Comprehensive assessment engine that evaluates policy indicators using advanced
     pattern recognition, multilingual support, and statistical validation methods.
     Includes parallel processing capabilities for large-scale analysis.
-    
+
     The scorer uses a weighted scoring system based on the presence and quality of:
     - Baseline values (40% weight)
-    - Targets/goals (40% weight)  
+    - Targets/goals (40% weight)
     - Time horizons (20% weight)
     - Quantitative components (10% bonus each)
-    
+
     Args:
         enable_parallel (bool, optional): Enable parallel processing. Defaults to True.
         n_jobs (int, optional): Number of parallel jobs. Defaults to None (auto-detect).
         backend (str, optional): Parallel backend ('loky', 'threading'). Defaults to 'loky'.
-        
+
     Attributes:
         detection_patterns (Dict): Compiled regex patterns by component type
         weights (Dict): Component weighting factors for scoring
         quality_thresholds (Dict): Quality tier classification thresholds
         logger (logging.Logger): Performance and error logger
-        
+
     Methods:
         calculate_feasibility_score: Score single indicator
         batch_score: Score multiple indicators with optional parallel processing
         detect_components: Detect all components in text
         batch_score_with_monitoring: Score with comprehensive performance monitoring
         get_detection_rules_documentation: Get complete documentation of detection rules
-        
+
     Example:
         >>> scorer = FeasibilityScorer(enable_parallel=True, n_jobs=4)
         >>> result = scorer.calculate_feasibility_score(
@@ -187,17 +193,17 @@ class FeasibilityScorer:
         ... )
         >>> print(f"Score: {result.feasibility_score:.2f}")
         >>> print(f"Tier: {result.quality_tier}")
-        
+
     Note:
         All text processing includes Unicode NFKC normalization for consistent
         handling of composed/decomposed characters and encoding variations.
         The system supports both Spanish and English pattern detection.
 
     """
-    
-    def __init__(self, enable_parallel=True, n_jobs=None, backend='loky'):
+
+    def __init__(self, enable_parallel=True, n_jobs=None, backend="loky"):
         """Initialize the feasibility scorer.
-        
+
         Args:
             enable_parallel: Enable parallel processing for batch operations.
             n_jobs: Number of parallel jobs (default: min(CPU count, 8)).
@@ -209,32 +215,29 @@ class FeasibilityScorer:
             ComponentType.TARGET: 0.4,
             ComponentType.TIME_HORIZON: 0.2,
             ComponentType.NUMERICAL: 0.1,
-            ComponentType.DATE: 0.1
+            ComponentType.DATE: 0.1,
         }
-        self.quality_thresholds = {
-            'high': 0.8,
-            'medium': 0.5,
-            'low': 0.2
-        }
-        
+        self.quality_thresholds = {"high": 0.8, "medium": 0.5, "low": 0.2}
+
         # Override with CLI arguments if available
-        cli_workers = os.environ.get('CLI_WORKERS')
+        cli_workers = os.environ.get("CLI_WORKERS")
         if cli_workers:
             n_jobs = int(cli_workers)
-        
+
         # Parallel processing configuration
         self.enable_parallel = enable_parallel and JOBLIB_AVAILABLE
-        self.n_jobs = n_jobs if n_jobs is not None else min(os.cpu_count() or 1, 8)
+        self.n_jobs = n_jobs if n_jobs is not None else min(
+            os.cpu_count() or 1, 8)
         self.backend = backend
-        
+
         # Performance logging setup
         self.logger = logging.getLogger(__name__)
         self._setup_logging()
-    
+
     def _setup_logging(self):
         """
         Setup comprehensive performance and error logging.
-        
+
         Configures logging with appropriate formatters and handlers for
         production monitoring and debugging capabilities.
 
@@ -242,24 +245,24 @@ class FeasibilityScorer:
         if not self.logger.handlers:
             handler = logging.StreamHandler()
             formatter = logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
             )
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
             self.logger.setLevel(logging.INFO)
-    
+
     def _initialize_patterns(self) -> Dict[ComponentType, List[Dict]]:
         """
         Initialize comprehensive regex patterns for multilingual component detection.
-        
+
         Creates and compiles regex patterns for detecting baseline values, targets,
         time horizons, numerical values, and dates in both Spanish and English text.
-        
+
         Returns:
             Dict[ComponentType, List[Dict]]: Dictionary mapping component types to
                                            lists of pattern dictionaries with regex,
                                            confidence, and language information
-                                           
+
         Note:
             Patterns are optimized for policy indicator analysis and include
             confidence levels based on specificity and reliability of detection.
@@ -268,124 +271,124 @@ class FeasibilityScorer:
         return {
             ComponentType.BASELINE: [
                 {
-                    'pattern': r'(?:línea\s+base|baseline|valor\s+inicial|situación\s+inicial|estado\s+actual)',
-                    'confidence': 0.9,
-                    'language': 'es/en'
+                    "pattern": r"(?:línea\s+base|baseline|valor\s+inicial|situación\s+inicial|estado\s+actual)",
+                    "confidence": 0.9,
+                    "language": "es/en",
                 },
                 {
-                    'pattern': r'(?:punto\s+de\s+partida|referencia\s+inicial|nivel\s+base)',
-                    'confidence': 0.8,
-                    'language': 'es'
+                    "pattern": r"(?:punto\s+de\s+partida|referencia\s+inicial|nivel\s+base)",
+                    "confidence": 0.8,
+                    "language": "es",
                 },
                 {
-                    'pattern': r'(?:current\s+level|initial\s+value|starting\s+point)',
-                    'confidence': 0.8,
-                    'language': 'en'
-                }
+                    "pattern": r"(?:current\s+level|initial\s+value|starting\s+point)",
+                    "confidence": 0.8,
+                    "language": "en",
+                },
             ],
             ComponentType.TARGET: [
                 {
-                    'pattern': r'(?:meta|objetivo|target|goal)',
-                    'confidence': 0.9,
-                    'language': 'es/en'
+                    "pattern": r"(?:meta|objetivo|target|goal)",
+                    "confidence": 0.9,
+                    "language": "es/en",
                 },
                 {
-                    'pattern': r'(?:propósito|finalidad|alcanzar|lograr|hasta)',
-                    'confidence': 0.7,
-                    'language': 'es'
+                    "pattern": r"(?:propósito|finalidad|alcanzar|lograr|hasta)",
+                    "confidence": 0.7,
+                    "language": "es",
                 },
                 {
-                    'pattern': r'(?:achieve|reach|attain|aim|to\s)',
-                    'confidence': 0.7,
-                    'language': 'en'
-                }
+                    "pattern": r"(?:achieve|reach|attain|aim|to\s)",
+                    "confidence": 0.7,
+                    "language": "en",
+                },
             ],
             ComponentType.TIME_HORIZON: [
                 {
-                    'pattern': r'(?:horizonte\s+temporal|plazo|período|periodo|duración)',
-                    'confidence': 0.9,
-                    'language': 'es'
+                    "pattern": r"(?:horizonte\s+temporal|plazo|período|periodo|duración)",
+                    "confidence": 0.9,
+                    "language": "es",
                 },
                 {
-                    'pattern': r'(?:time\s+horizon|timeline|timeframe|duration|period)',
-                    'confidence': 0.9,
-                    'language': 'en'
+                    "pattern": r"(?:time\s+horizon|timeline|timeframe|duration|period)",
+                    "confidence": 0.9,
+                    "language": "en",
                 },
                 {
-                    'pattern': r'(?:para\s+el\s+año|hasta\s+el|en\s+los\s+próximos|within|by\s+\d{4})',
-                    'confidence': 0.8,
-                    'language': 'es/en'
-                }
+                    "pattern": r"(?:para\s+el\s+año|hasta\s+el|en\s+los\s+próximos|within|by\s+\d{4})",
+                    "confidence": 0.8,
+                    "language": "es/en",
+                },
             ],
             ComponentType.NUMERICAL: [
                 {
-                    'pattern': r'\d+(?:[.,]\d+)?(?:\s*%|\s*por\s*ciento|\s*percent)',
-                    'confidence': 0.95,
-                    'language': 'universal'
+                    "pattern": r"\d+(?:[.,]\d+)?(?:\s*%|\s*por\s*ciento|\s*percent)",
+                    "confidence": 0.95,
+                    "language": "universal",
                 },
                 {
-                    'pattern': r'\d+(?:[.,]\d+)?\s*(?:millones?|millions?|mil|thousand)',
-                    'confidence': 0.9,
-                    'language': 'es/en'
+                    "pattern": r"\d+(?:[.,]\d+)?\s*(?:millones?|millions?|mil|thousand)",
+                    "confidence": 0.9,
+                    "language": "es/en",
                 },
                 {
-                    'pattern': r'(?:incrementar|aumentar|reducir|disminuir|increase|reduce)\s+(?:en\s+|by\s+)?\d+',
-                    'confidence': 0.85,
-                    'language': 'es/en'
-                }
+                    "pattern": r"(?:incrementar|aumentar|reducir|disminuir|increase|reduce)\s+(?:en\s+|by\s+)?\d+",
+                    "confidence": 0.85,
+                    "language": "es/en",
+                },
             ],
             ComponentType.DATE: [
                 {
-                    'pattern': r'\b(?:20\d{2}|19\d{2})\b',
-                    'confidence': 0.9,
-                    'language': 'universal'
+                    "pattern": r"\b(?:20\d{2}|19\d{2})\b",
+                    "confidence": 0.9,
+                    "language": "universal",
                 },
                 {
-                    'pattern': r'(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?20\d{2}',
-                    'confidence': 0.95,
-                    'language': 'es'
+                    "pattern": r"(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)\s+(?:de\s+)?20\d{2}",
+                    "confidence": 0.95,
+                    "language": "es",
                 },
                 {
-                    'pattern': r'(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+20\d{2}',
-                    'confidence': 0.95,
-                    'language': 'en'
+                    "pattern": r"(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+20\d{2}",
+                    "confidence": 0.95,
+                    "language": "en",
                 },
                 {
-                    'pattern': r'\d{1,2}[-/]\d{1,2}[-/](?:20\d{2}|\d{2})',
-                    'confidence': 0.8,
-                    'language': 'universal'
-                }
-            ]
+                    "pattern": r"\d{1,2}[-/]\d{1,2}[-/](?:20\d{2}|\d{2})",
+                    "confidence": 0.8,
+                    "language": "universal",
+                },
+            ],
         }
-    
+
     def _normalize_text(self, text: str) -> str:
         """
         Normalize text using Unicode NFKC normalization for consistent character representation.
-        
+
         Args:
             text (str): Input text to normalize
-            
+
         Returns:
             str: Normalized text with consistent Unicode representation
-            
+
         Note:
             Uses NFKC normalization to handle composed/decomposed characters,
             compatibility characters, and encoding variations consistently.
 
         """
-        return unicodedata.normalize('NFKC', text)
-    
+        return unicodedata.normalize("NFKC", text)
+
     def detect_components(self, text: str) -> List[DetectionResult]:
         """
         Detect all components in the given text using comprehensive regex patterns.
-        
+
         Args:
             text (str): Text to analyze for indicator components
-            
+
         Returns:
             List[DetectionResult]: List of detected components with confidence scores
                                   and position information
-                                  
+
         Note:
             Applies Unicode normalization before pattern matching to ensure
             consistent detection across different text encodings and formats.
@@ -395,38 +398,40 @@ class FeasibilityScorer:
         # Apply Unicode normalization before processing
         normalized_text = FeasibilityScorer._normalize_text(text)
         text_lower = normalized_text.lower()
-        
+
         for component_type, patterns in self.detection_patterns.items():
             for pattern_info in patterns:
-                pattern = pattern_info['pattern']
-                confidence = pattern_info['confidence']
-                
+                pattern = pattern_info["pattern"]
+                confidence = pattern_info["confidence"]
+
                 matches = re.finditer(pattern, text_lower, re.IGNORECASE)
                 for match in matches:
                     result = DetectionResult(
                         component_type=component_type,
                         matched_text=match.group(),
                         confidence=confidence,
-                        position=match.start()
+                        position=match.start(),
                     )
                     results.append(result)
-        
+
         return results
-    
-    def _has_quantitative_component(self, text: str, component_type: ComponentType) -> bool:
+
+    def _has_quantitative_component(
+        self, text: str, component_type: ComponentType
+    ) -> bool:
         """
         Check if a component has quantitative elements in nearby context.
-        
+
         Analyzes text around component mentions to determine if quantitative
         values are associated with baseline or target components.
-        
+
         Args:
             text (str): Text to analyze
             component_type (ComponentType): Component type to check for quantitative association
-            
+
         Returns:
             bool: True if quantitative elements are found within 30 characters of component mentions
-            
+
         Note:
             Uses a 30-character context window around component mentions to identify
             associated numerical values, percentages, or quantitative indicators.
@@ -435,57 +440,57 @@ class FeasibilityScorer:
         # Apply Unicode normalization before processing
         normalized_text = FeasibilityScorer._normalize_text(text)
         text_lower = normalized_text.lower()
-        
+
         # Find component mentions
         component_positions = []
         for pattern_info in self.detection_patterns[component_type]:
-            pattern = pattern_info['pattern']
+            pattern = pattern_info["pattern"]
             matches = re.finditer(pattern, text_lower, re.IGNORECASE)
             component_positions.extend([match.start() for match in matches])
-        
+
         if not component_positions:
             return False
-        
+
         # Check for numerical values within 30 characters of component mentions
         numerical_patterns = self.detection_patterns[ComponentType.NUMERICAL]
         for pos in component_positions:
             context_start = max(0, pos - 30)
             context_end = min(len(text), pos + 30)
             context = text_lower[context_start:context_end]
-            
+
             for pattern_info in numerical_patterns:
-                if re.search(pattern_info['pattern'], context, re.IGNORECASE):
+                if re.search(pattern_info["pattern"], context, re.IGNORECASE):
                     return True
-        
+
         return False
-    
+
     def calculate_feasibility_score(self, text: str) -> IndicatorScore:
         """
         Calculate comprehensive feasibility score based on detected components and quality.
-        
+
         Implements sophisticated scoring algorithm with mandatory requirements and
         bonus components for comprehensive indicator quality assessment.
-        
+
         Args:
             text (str): Indicator text to evaluate
-            
+
         Returns:
             IndicatorScore: Comprehensive score with detailed analysis
-            
+
         Scoring Requirements:
             - Must have both baseline and target components for positive score
-            - Base score: 0.8 (0.4 baseline + 0.4 target)  
+            - Base score: 0.8 (0.4 baseline + 0.4 target)
             - Quantitative bonuses: +0.2 each for quantitative baseline and target
             - Component bonuses: +0.2 time horizon, +0.1 numerical, +0.1 dates
             - Confidence weighting: Final score multiplied by average pattern confidence
-            
+
         Quality Tiers:
             - "high": ≥0.8 score
-            - "medium": ≥0.5 score  
+            - "medium": ≥0.5 score
             - "low": ≥0.2 score
             - "poor": <0.2 score
             - "insufficient": Missing baseline or target
-            
+
         Note:
             All text processing includes Unicode normalization for consistent
             handling of different character encodings and compositions.
@@ -493,28 +498,35 @@ class FeasibilityScorer:
         """
         # Check for zero evidence support condition first
         if evidencia_soporte is not None and evidencia_soporte == 0:
-            self.logger.warning("Zero evidence support detected - overriding normal scoring logic")
-            self.logger.info("Risk level set to HIGH due to lack of supporting evidence")
-            self.logger.info("Final recommendation overridden to: REQUIERE MAYOR EVIDENCIA")
-            
+            self.logger.warning(
+                "Zero evidence support detected - overriding normal scoring logic"
+            )
+            self.logger.info(
+                "Risk level set to HIGH due to lack of supporting evidence"
+            )
+            self.logger.info(
+                "Final recommendation overridden to: REQUIERE MAYOR EVIDENCIA"
+            )
+
             return IndicatorScore(
                 feasibility_score=0.0,  # High risk = low feasibility score
                 components_detected=[],
                 detailed_matches=[],
                 has_quantitative_baseline=False,
                 has_quantitative_target=False,
-                quality_tier='REQUIERE MAYOR EVIDENCIA'  # Override recommendation
+                quality_tier="REQUIERE MAYOR EVIDENCIA",  # Override recommendation
             )
-        
+
         # Apply Unicode normalization at entry point
         normalized_text = FeasibilityScorer._normalize_text(text)
         detected_components = self.detect_components(normalized_text)
-        component_types = set(result.component_type for result in detected_components)
-        
+        component_types = set(
+            result.component_type for result in detected_components)
+
         # Check mandatory requirements
         has_baseline = ComponentType.BASELINE in component_types
         has_target = ComponentType.TARGET in component_types
-        
+
         if not (has_baseline and has_target):
             return IndicatorScore(
                 feasibility_score=0.0,
@@ -522,202 +534,253 @@ class FeasibilityScorer:
                 detailed_matches=detected_components,
                 has_quantitative_baseline=False,
                 has_quantitative_target=False,
-                quality_tier='insufficient'
+                quality_tier="insufficient",
             )
-        
+
         # Calculate base score from mandatory components
         base_score = (
-            self.weights[ComponentType.BASELINE] + 
+            self.weights[ComponentType.BASELINE] +
             self.weights[ComponentType.TARGET]
         )
-        
+
         # Check for quantitative components (use normalized text)
-        has_quantitative_baseline = self._has_quantitative_component(normalized_text, ComponentType.BASELINE)
-        has_quantitative_target = self._has_quantitative_component(normalized_text, ComponentType.TARGET)
-        
+        has_quantitative_baseline = self._has_quantitative_component(
+            normalized_text, ComponentType.BASELINE
+        )
+        has_quantitative_target = self._has_quantitative_component(
+            normalized_text, ComponentType.TARGET
+        )
+
         # Bonus for quantitative elements
         if has_quantitative_baseline:
             base_score += 0.2
         if has_quantitative_target:
             base_score += 0.2
-        
+
         # Additional component bonuses
         if ComponentType.TIME_HORIZON in component_types:
             base_score += self.weights[ComponentType.TIME_HORIZON]
-        
+
         if ComponentType.NUMERICAL in component_types:
             base_score += self.weights[ComponentType.NUMERICAL]
-        
+
         if ComponentType.DATE in component_types:
             base_score += self.weights[ComponentType.DATE]
-        
+
         # Apply confidence weighting
-        avg_confidence = sum(result.confidence for result in detected_components) / len(detected_components)
+        avg_confidence = sum(result.confidence for result in detected_components) / len(
+            detected_components
+        )
         final_score = min(1.0, base_score * avg_confidence)
-        
+
         # Determine quality tier - check again for zero evidence support override
         if evidencia_soporte is not None and evidencia_soporte == 0:
-            quality_tier = 'REQUIERE MAYOR EVIDENCIA'
-        elif final_score >= self.quality_thresholds['high']:
-            quality_tier = 'high'
-        elif final_score >= self.quality_thresholds['medium']:
-            quality_tier = 'medium'
-        elif final_score >= self.quality_thresholds['low']:
-            quality_tier = 'low'
+            quality_tier = "REQUIERE MAYOR EVIDENCIA"
+        elif final_score >= self.quality_thresholds["high"]:
+            quality_tier = "high"
+        elif final_score >= self.quality_thresholds["medium"]:
+            quality_tier = "medium"
+        elif final_score >= self.quality_thresholds["low"]:
+            quality_tier = "low"
         else:
-            quality_tier = 'poor'
-        
+            quality_tier = "poor"
+
         return IndicatorScore(
             feasibility_score=final_score,
             components_detected=list(component_types),
             detailed_matches=detected_components,
             has_quantitative_baseline=has_quantitative_baseline,
             has_quantitative_target=has_quantitative_target,
-            quality_tier=quality_tier
+            quality_tier=quality_tier,
         )
-    
+
     def _score_single_indicator(self, indicator: str) -> IndicatorScore:
         """Score a single indicator - helper function for parallel processing.
-        
+
         Args:
             indicator: Indicator text to score.
-            
+
         Returns:
             IndicatorScore for the given indicator.
         """
         return self.calculate_feasibility_score(indicator)
-    
-    def batch_score(self, indicators: List[str], compare_backends=False, use_parallel: bool = False) -> List[IndicatorScore]:
+
+    def batch_score(
+        self, indicators: List[str], compare_backends=False, use_parallel: bool = False
+    ) -> List[IndicatorScore]:
         """Score multiple indicators with optional parallel processing.
-        
+
         Processes a batch of indicators with automatic selection of sequential
         or parallel processing based on batch size and system capabilities.
-        
+
         Args:
             indicators: List of indicator strings to score.
             compare_backends: If True, compare performance between threading and loky backends.
             use_parallel: Legacy parameter for backward compatibility.
-            
+
         Returns:
             List of IndicatorScore results in the same order as input indicators.
         """
         if not indicators:
             return []
-            
+
         # Validate evidencia_soporte_list length if provided
-        if evidencia_soporte_list is not None and len(evidencia_soporte_list) != len(indicators):
-            raise ValueError("evidencia_soporte_list must have the same length as indicators")
-            
+        if evidencia_soporte_list is not None and len(evidencia_soporte_list) != len(
+            indicators
+        ):
+            raise ValueError(
+                "evidencia_soporte_list must have the same length as indicators"
+            )
+
         # For small batches, use sequential processing to avoid overhead
         if len(indicators) < 10 or not self.enable_parallel or not JOBLIB_AVAILABLE:
             return self._batch_score_sequential(indicators, evidencia_soporte_list)
-            
+
         if compare_backends:
             return self._batch_score_with_comparison(indicators, evidencia_soporte_list)
         else:
-            return self._batch_score_parallel(indicators, self.backend, evidencia_soporte_list)
-    
-    def _batch_score_sequential(self, indicators: List[str], evidencia_soporte_list: Optional[List[Optional[int]]] = None) -> List[IndicatorScore]:
+            return self._batch_score_parallel(
+                indicators, self.backend, evidencia_soporte_list
+            )
+
+    def _batch_score_sequential(
+        self,
+        indicators: List[str],
+        evidencia_soporte_list: Optional[List[Optional[int]]] = None,
+    ) -> List[IndicatorScore]:
         """Sequential batch scoring."""
         start_time = time.time()
         results = []
         for i, indicator in enumerate(indicators):
-            evidencia_soporte = evidencia_soporte_list[i] if evidencia_soporte_list else None
-            results.append(self.calculate_feasibility_score(indicator, evidencia_soporte))
+            evidencia_soporte = (
+                evidencia_soporte_list[i] if evidencia_soporte_list else None
+            )
+            results.append(
+                self.calculate_feasibility_score(indicator, evidencia_soporte)
+            )
         elapsed = time.time() - start_time
-        
-        self.logger.info(f"Sequential processing: {len(indicators)} indicators in {elapsed:.3f}s "
-                        f"({elapsed/len(indicators)*1000:.1f}ms per indicator)")
+
+        self.logger.info(
+            f"Sequential processing: {len(indicators)} indicators in {elapsed:.3f}s "
+            f"({elapsed / len(indicators) * 1000:.1f}ms per indicator)"
+        )
         return results
-    
-    def _batch_score_parallel(self, indicators: List[str], backend: str, evidencia_soporte_list: Optional[List[Optional[int]]] = None) -> List[IndicatorScore]:
+
+    def _batch_score_parallel(
+        self,
+        indicators: List[str],
+        backend: str,
+        evidencia_soporte_list: Optional[List[Optional[int]]] = None,
+    ) -> List[IndicatorScore]:
         """Parallel batch scoring using specified backend."""
         if not JOBLIB_AVAILABLE:
             raise RuntimeError("joblib not available for parallel processing")
-            
+
         start_time = time.time()
-        
+
         # Create a picklable instance for parallel processing
         scorer_copy = self._create_picklable_copy()
-        
+
         with Parallel(n_jobs=self.n_jobs, backend=backend) as parallel:
             results = parallel(
                 delayed(scorer_copy._score_single_indicator)(
-                    indicator, 
-                    evidencia_soporte_list[i] if evidencia_soporte_list else None
-                ) 
+                    indicator,
+                    evidencia_soporte_list[i] if evidencia_soporte_list else None,
+                )
                 for i, indicator in enumerate(indicators)
             )
-        
+
         elapsed = time.time() - start_time
-        self.logger.info(f"Parallel processing ({backend}): {len(indicators)} indicators in {elapsed:.3f}s "
-                        f"({elapsed/len(indicators)*1000:.1f}ms per indicator, {self.n_jobs} workers)")
+        self.logger.info(
+            f"Parallel processing ({backend}): {len(indicators)} indicators in {elapsed:.3f}s "
+            f"({elapsed / len(indicators) * 1000:.1f}ms per indicator, {self.n_jobs} workers)"
+        )
         return results
-    
-    def _batch_score_with_comparison(self, indicators: List[str], evidencia_soporte_list: Optional[List[Optional[int]]] = None) -> List[IndicatorScore]:
+
+    def _batch_score_with_comparison(
+        self,
+        indicators: List[str],
+        evidencia_soporte_list: Optional[List[Optional[int]]] = None,
+    ) -> List[IndicatorScore]:
         """Score batch with performance comparison between backends."""
         if not JOBLIB_AVAILABLE:
-            self.logger.warning("joblib not available, falling back to sequential processing")
+            self.logger.warning(
+                "joblib not available, falling back to sequential processing"
+            )
             return self._batch_score_sequential(indicators, evidencia_soporte_list)
-            
+
         self.logger.info("Comparing parallel processing backends...")
-        
+
         # Test with threading backend
         try:
-            threading_results = self._batch_score_parallel(indicators, 'threading', evidencia_soporte_list)
+            threading_results = self._batch_score_parallel(
+                indicators, "threading", evidencia_soporte_list
+            )
         except Exception as e:
             self.logger.warning(f"Threading backend failed: {e}")
             threading_results = None
-        
-        # Test with loky backend  
+
+        # Test with loky backend
         try:
-            loky_results = self._batch_score_parallel(indicators, 'loky', evidencia_soporte_list)
+            loky_results = self._batch_score_parallel(
+                indicators, "loky", evidencia_soporte_list
+            )
         except Exception as e:
             self.logger.warning(f"Loky backend failed: {e}")
             loky_results = None
-            
+
         # Fallback to sequential if both failed
         if loky_results is None and threading_results is None:
-            self.logger.warning("Both parallel backends failed, falling back to sequential")
+            self.logger.warning(
+                "Both parallel backends failed, falling back to sequential"
+            )
             return self._batch_score_sequential(indicators, evidencia_soporte_list)
-            
+
         # Return loky results if available, otherwise threading results
         return loky_results if loky_results is not None else threading_results
-    
+
     def _create_picklable_copy(self):
         """Create a copy of the scorer that can be safely pickled for multiprocessing."""
         # Create new instance with same configuration but fresh logger
         new_scorer = FeasibilityScorer(
             enable_parallel=False,  # Disable parallel in workers to avoid recursion
             n_jobs=self.n_jobs,
-            backend=self.backend
+            backend=self.backend,
         )
-        
+
         # Copy over the patterns and weights (these are picklable)
         new_scorer.detection_patterns = self.detection_patterns
         new_scorer.weights = self.weights
         new_scorer.quality_thresholds = self.quality_thresholds
-        
+
         return new_scorer
-    
-    def batch_score_with_monitoring(self, indicators: List[str], evidencia_soporte_list: Optional[List[Optional[int]]] = None) -> BatchScoreResult:
+
+    def batch_score_with_monitoring(
+        self,
+        indicators: List[str],
+        evidencia_soporte_list: Optional[List[Optional[int]]] = None,
+    ) -> BatchScoreResult:
         """Score multiple indicators with execution monitoring."""
         start_time = time.time()
-        
+
         scores = []
         for i, indicator in enumerate(indicators):
-            evidencia_soporte = evidencia_soporte_list[i] if evidencia_soporte_list else None
-            scores.append(self.calculate_feasibility_score(indicator, evidencia_soporte))
-        
+            evidencia_soporte = (
+                evidencia_soporte_list[i] if evidencia_soporte_list else None
+            )
+            scores.append(
+                self.calculate_feasibility_score(indicator, evidencia_soporte)
+            )
+
         end_time = time.time()
         duracion_segundos = end_time - start_time
-        
+
         # Calculate processing rate (plans per minute)
         if duracion_segundos > 0:
             planes_por_minuto = (len(indicators) / duracion_segundos) * 60
         else:
             planes_por_minuto = 0.0
-        
+
         # Format human-readable time
         if duracion_segundos < 1:
             execution_time = f"{duracion_segundos * 1000:.1f}ms"
@@ -727,15 +790,15 @@ class FeasibilityScorer:
             minutes = int(duracion_segundos // 60)
             seconds = duracion_segundos % 60
             execution_time = f"{minutes}m {seconds:.1f}s"
-        
+
         return BatchScoreResult(
             scores=scores,
             total_indicators=len(indicators),
             execution_time=execution_time,
             duracion_segundos=duracion_segundos,
-            planes_por_minuto=planes_por_minuto
+            planes_por_minuto=planes_por_minuto,
         )
-    
+
     @staticmethod
     def get_detection_rules_documentation() -> str:
         """Return comprehensive documentation of detection rules."""
@@ -809,293 +872,294 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
 - ✗ No quantitative elements
 """
         return doc
-    
+
     def calcular_calidad_evidencia(self, fragment: str) -> float:
         """
         Calculate evidence quality score for text fragments (0.0 to 1.0).
-        
+
         Higher scores for fragments containing:
         - Numerical values with monetary amounts (COP, $, millones)
         - Dates (YYYY format, quarters Q1-Q4, months)
         - Measurement terminology (baseline, meta, periodicidad)
-        
+
         Penalties applied for:
         - Indicators appearing only in titles/bullet points without values
         - Empty or malformed content
-        
+
         Args:
             fragment (str): Text fragment to analyze
-            
+
         Returns:
             float: Quality score between 0.0 and 1.0
         """
         if not fragment or not fragment.strip():
             return 0.0
-        
+
         # Normalize Unicode text using NFKC
-        normalized_text = unicodedata.normalize('NFKC', fragment.strip())
+        normalized_text = unicodedata.normalize("NFKC", fragment.strip())
         text_lower = normalized_text.lower()
-        
+
         # Initialize scoring components
         scores = {
-            'monetary': 0.0,
-            'dates': 0.0,
-            'terminology': 0.0,
-            'structure_penalty': 0.0
+            "monetary": 0.0,
+            "dates": 0.0,
+            "terminology": 0.0,
+            "structure_penalty": 0.0,
         }
-        
+
         # Weights for different scoring components
         weights = {
-            'monetary': 0.35,
-            'dates': 0.25,
-            'terminology': 0.25,
-            'structure_penalty': -0.15
+            "monetary": 0.35,
+            "dates": 0.25,
+            "terminology": 0.25,
+            "structure_penalty": -0.15,
         }
-        
+
         # 1. Monetary amount detection
-        scores['monetary'] = self._detect_monetary_values(text_lower)
-        
-        # 2. Date detection  
-        scores['dates'] = self._detect_temporal_indicators(text_lower)
-        
+        scores["monetary"] = self._detect_monetary_values(text_lower)
+
+        # 2. Date detection
+        scores["dates"] = self._detect_temporal_indicators(text_lower)
+
         # 3. Measurement terminology detection
-        scores['terminology'] = self._detect_measurement_terminology(text_lower)
-        
+        scores["terminology"] = self._detect_measurement_terminology(
+            text_lower)
+
         # 4. Structure penalty for title-only indicators
-        scores['structure_penalty'] = self._calculate_structure_penalty(normalized_text)
-        
+        scores["structure_penalty"] = self._calculate_structure_penalty(
+            normalized_text)
+
         # Calculate weighted final score
-        final_score = sum(scores[component] * weights[component] 
-                         for component in scores.keys())
-        
+        final_score = sum(
+            scores[component] * weights[component] for component in scores.keys()
+        )
+
         # Ensure score is between 0.0 and 1.0
         return max(0.0, min(1.0, final_score))
-    
+
     @staticmethod
     def _detect_monetary_values(text: str) -> float:
         """Detect monetary amounts and return normalized score."""
         monetary_patterns = [
             # Colombian pesos with COP
-            r'cop\s*[\$]?\s*[\d,.\s]+(?:millones?|mil|thousands?|millions?)?',
-            
+            r"cop\s*[\$]?\s*[\d,.\s]+(?:millones?|mil|thousands?|millions?)?",
             # Dollar amounts with various formats
-            r'[\$]\s*[\d,.\s]+(?:millones?|mil|thousands?|millions?)?',
-            r'[\d,.\s]+\s*(?:dollars?|dolares?|usd)',
-            
+            r"[\$]\s*[\d,.\s]+(?:millones?|mil|thousands?|millions?)?",
+            r"[\d,.\s]+\s*(?:dollars?|dolares?|usd)",
             # Millions/thousands indicators in Spanish/English
-            r'[\d,.\s]+\s*(?:millones?|millions?)\s*(?:de\s*)?(?:pesos?|cop|[\$])?',
-            r'[\d,.\s]+\s*mil(?:es)?\s*(?:pesos?|cop|[\$])?',
-            
+            r"[\d,.\s]+\s*(?:millones?|millions?)\s*(?:de\s*)?(?:pesos?|cop|[\$])?",
+            r"[\d,.\s]+\s*mil(?:es)?\s*(?:pesos?|cop|[\$])?",
             # Percentage with monetary context
-            r'[\d,.\s]+\s*%\s*(?:del\s*)?(?:presupuesto|budget|recursos?)',
-            
+            r"[\d,.\s]+\s*%\s*(?:del\s*)?(?:presupuesto|budget|recursos?)",
             # Investment/cost terminology
-            r'(?:inversion|investment|costo|cost|gasto|expense).*?[\d,.\s]+',
-            r'[\d,.\s]+.*?(?:inversion|investment|costo|cost)'
+            r"(?:inversion|investment|costo|cost|gasto|expense).*?[\d,.\s]+",
+            r"[\d,.\s]+.*?(?:inversion|investment|costo|cost)",
         ]
-        
+
         matches = []
         for pattern in monetary_patterns:
             matches.extend(re.finditer(pattern, text, re.IGNORECASE))
-        
+
         if not matches:
             return 0.0
-        
+
         # Score based on number and quality of monetary references
         base_score = min(len(matches) * 0.3, 1.0)
-        
+
         # Bonus for high-precision monetary values
         precision_bonus = 0.0
         for match in matches:
             match_text = match.group()
             # Look for decimal places or specific amounts
-            if re.search(r'[\d]+[.,][\d]{1,3}', match_text):
+            if re.search(r"[\d]+[.,][\d]{1,3}", match_text):
                 precision_bonus += 0.1
             # Look for currency symbols
-            if re.search(r'[\$]|cop|usd', match_text):
+            if re.search(r"[\$]|cop|usd", match_text):
                 precision_bonus += 0.1
-        
+
         return min(base_score + precision_bonus, 1.0)
-    
+
     @staticmethod
     def _detect_temporal_indicators(text: str) -> float:
         """Detect dates and temporal indicators."""
         temporal_patterns = [
             # Year patterns (YYYY)
-            r'\b(?:20[0-9]{2}|19[0-9]{2})\b',
-            
+            r"\b(?:20[0-9]{2}|19[0-9]{2})\b",
             # Quarter patterns (Q1-Q4)
-            r'q[1-4](?:\s+20[0-9]{2})?',
-            r'(?:trimestre|quarter)\s*[1-4]',
-            r'(?:primer|segundo|tercer|cuarto)\s*trimestre',
-            
+            r"q[1-4](?:\s+20[0-9]{2})?",
+            r"(?:trimestre|quarter)\s*[1-4]",
+            r"(?:primer|segundo|tercer|cuarto)\s*trimestre",
             # Month patterns in Spanish
-            r'(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)(?:\s+(?:de\s+)?20[0-9]{2})?',
-            
-            # Month patterns in English  
-            r'(?:january|february|march|april|may|june|july|august|september|october|november|december)(?:\s+20[0-9]{2})?',
-            
+            r"(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)(?:\s+(?:de\s+)?20[0-9]{2})?",
+            # Month patterns in English
+            r"(?:january|february|march|april|may|june|july|august|september|october|november|december)(?:\s+20[0-9]{2})?",
             # Date formats
-            r'\b\d{1,2}[-/]\d{1,2}[-/](?:20[0-9]{2}|\d{2})\b',
-            r'\b\d{4}[-/]\d{1,2}[-/]\d{1,2}\b',
-            
+            r"\b\d{1,2}[-/]\d{1,2}[-/](?:20[0-9]{2}|\d{2})\b",
+            r"\b\d{4}[-/]\d{1,2}[-/]\d{1,2}\b",
             # Relative temporal references
-            r'(?:periodicidad|periodicity|frequency).*?(?:anual|annual|mensual|monthly|trimestral|quarterly)',
-            r'(?:cada|every)\s+(?:\d+\s+)?(?:años?|years?|meses?|months?|trimestres?|quarters?)',
-            
+            r"(?:periodicidad|periodicity|frequency).*?(?:anual|annual|mensual|monthly|trimestral|quarterly)",
+            r"(?:cada|every)\s+(?:\d+\s+)?(?:años?|years?|meses?|months?|trimestres?|quarters?)",
             # Time horizons
-            r'(?:para|by|hasta|until|en)\s+(?:el\s+)?(?:año\s+)?20[0-9]{2}',
-            r'(?:horizon|horizonte).*?(?:20[0-9]{2}|\d+\s+años?)'
+            r"(?:para|by|hasta|until|en)\s+(?:el\s+)?(?:año\s+)?20[0-9]{2}",
+            r"(?:horizon|horizonte).*?(?:20[0-9]{2}|\d+\s+años?)",
         ]
-        
+
         matches = []
         for pattern in temporal_patterns:
             matches.extend(re.finditer(pattern, text, re.IGNORECASE))
-        
+
         if not matches:
             return 0.0
-        
+
         # Score based on temporal precision
         score = 0.0
         for match in matches:
             match_text = match.group()
             # Higher score for specific dates
-            if re.search(r'20[0-9]{2}', match_text):
+            if re.search(r"20[0-9]{2}", match_text):
                 score += 0.4
-            elif re.search(r'q[1-4]|trimestre|quarter', match_text):
+            elif re.search(r"q[1-4]|trimestre|quarter", match_text):
                 score += 0.3
-            elif re.search(r'enero|febrero|january|february', match_text):
+            elif re.search(r"enero|febrero|january|february", match_text):
                 score += 0.25
             else:
                 score += 0.15
-        
+
         return min(score, 1.0)
-    
+
     @staticmethod
     def _detect_measurement_terminology(text: str) -> float:
         """Detect measurement and evaluation terminology."""
         terminology_patterns = [
             # Baseline terminology
-            r'(?:baseline|línea\s+base|valor\s+inicial|situación\s+inicial)',
-            r'(?:punto\s+de\s+partida|referencia\s+inicial|estado\s+actual)',
-            
-            # Target/goal terminology  
-            r'(?:meta|objetivo|target|goal|propósito)',
-            r'(?:alcanzar|lograr|achieve|reach)',
-            
+            r"(?:baseline|línea\s+base|valor\s+inicial|situación\s+inicial)",
+            r"(?:punto\s+de\s+partida|referencia\s+inicial|estado\s+actual)",
+            # Target/goal terminology
+            r"(?:meta|objetivo|target|goal|propósito)",
+            r"(?:alcanzar|lograr|achieve|reach)",
             # Measurement concepts
-            r'(?:periodicidad|periodicity|frecuencia|frequency)',
-            r'(?:indicador|indicator|métrica|metric|medición|measurement)',
-            r'(?:monitoreo|monitoring|seguimiento|tracking)',
-            
+            r"(?:periodicidad|periodicity|frecuencia|frequency)",
+            r"(?:indicador|indicator|métrica|metric|medición|measurement)",
+            r"(?:monitoreo|monitoring|seguimiento|tracking)",
             # Performance terminology
-            r'(?:desempeño|performance|resultado|result|impacto|impact)',
-            r'(?:evaluación|evaluation|assessment|valoración)',
-            
+            r"(?:desempeño|performance|resultado|result|impacto|impact)",
+            r"(?:evaluación|evaluation|assessment|valoración)",
             # Quantitative terms
-            r'(?:incremento|aumento|reducción|mejora|improvement)',
-            r'(?:porcentaje|percentage|proporción|proportion|ratio)',
-            
+            r"(?:incremento|aumento|reducción|mejora|improvement)",
+            r"(?:porcentaje|percentage|proporción|proportion|ratio)",
             # Comparative terms
-            r'(?:comparado\s+con|compared\s+to|respecto\s+a|versus)',
-            r'(?:mayor\s+que|menor\s+que|igual\s+a|greater\s+than|less\s+than)'
+            r"(?:comparado\s+con|compared\s+to|respecto\s+a|versus)",
+            r"(?:mayor\s+que|menor\s+que|igual\s+a|greater\s+than|less\s+than)",
         ]
-        
+
         matches = []
         for pattern in terminology_patterns:
             matches.extend(re.finditer(pattern, text, re.IGNORECASE))
-        
+
         if not matches:
             return 0.0
-        
+
         # Score based on terminology richness
         unique_matches = set(match.group().lower() for match in matches)
         richness_score = min(len(unique_matches) * 0.2, 1.0)
-        
+
         # Bonus for measurement-specific terminology
         measurement_bonus = 0.0
-        measurement_terms = ['periodicidad', 'periodicity', 'indicador', 'indicator', 
-                           'monitoreo', 'monitoring', 'evaluación', 'evaluation']
-        
+        measurement_terms = [
+            "periodicidad",
+            "periodicity",
+            "indicador",
+            "indicator",
+            "monitoreo",
+            "monitoring",
+            "evaluación",
+            "evaluation",
+        ]
+
         for term in measurement_terms:
             if term in text:
                 measurement_bonus += 0.15
-        
+
         return min(richness_score + measurement_bonus, 1.0)
-    
+
     @staticmethod
     def _calculate_structure_penalty(text: str) -> float:
         """Calculate penalty for indicators in titles/bullets without values."""
         # Check for title/bullet point patterns
         title_patterns = [
-            r'^[-•*]\s+',  # Bullet points
-            r'^#{1,6}\s+', # Markdown headers
-            r'^[A-Z\s]+:$', # All caps titles with colon
-            r'^[^\w]*(?:[A-Z][^.]*[^.]|[A-Z\s]+)$'  # Title-like structure
+            r"^[-•*]\s+",  # Bullet points
+            r"^#{1,6}\s+",  # Markdown headers
+            r"^[A-Z\s]+:$",  # All caps titles with colon
+            r"^[^\w]*(?:[A-Z][^.]*[^.]|[A-Z\s]+)$",  # Title-like structure
         ]
-        
-        is_title_like = any(re.match(pattern, text, re.MULTILINE) 
-                           for pattern in title_patterns)
-        
+
+        is_title_like = any(
+            re.match(pattern, text, re.MULTILINE) for pattern in title_patterns
+        )
+
         if not is_title_like:
             return 0.0
-        
+
         # Check if title has associated quantitative values
         value_patterns = [
-            r'\d+(?:[.,]\d+)?(?:\s*%|\s*millones?|\s*mil)',
-            r'[\$][\d,.\s]+',
-            r'cop\s*[\d,.\s]+',
-            r'\d{4}',  # Years
-            r'q[1-4]'  # Quarters
+            r"\d+(?:[.,]\d+)?(?:\s*%|\s*millones?|\s*mil)",
+            r"[\$][\d,.\s]+",
+            r"cop\s*[\d,.\s]+",
+            r"\d{4}",  # Years
+            r"q[1-4]",  # Quarters
         ]
-        
-        has_values = any(re.search(pattern, text, re.IGNORECASE) 
-                        for pattern in value_patterns)
-        
+
+        has_values = any(
+            re.search(pattern, text, re.IGNORECASE) for pattern in value_patterns
+        )
+
         # Apply penalty if title-like without values
         return 1.0 if not has_values else 0.0
-    
+
     def generate_report(self, indicators: List[str], output_path: str) -> None:
         """
         Generate a comprehensive feasibility report and save it to file using atomic operations.
-        
-        Uses atomic file operations to prevent corrupted output files if the process is 
+
+        Uses atomic file operations to prevent corrupted output files if the process is
         interrupted during report generation. This is achieved by:
         1. Writing the complete report content to a temporary file in the same directory
         2. Using Path.rename() to atomically move the temporary file to the final destination
-        
+
         Note: Atomicity may not be guaranteed on some remote filesystems (NFS, SMB) due to
         their implementation of rename operations. For local filesystems (ext4, NTFS, APFS),
         the rename operation is atomic.
-        
+
         Args:
             indicators: List of indicator texts to analyze
             output_path: Path where the report should be saved
-            
+
         Raises:
             IOError: If file operations fail
             ValueError: If indicators list is empty
         """
         if not indicators:
             raise ValueError("Indicators list cannot be empty")
-        
+
         output_file = Path(output_path)
-        
+
         # Create a unique temporary file in the same directory as the target
-        temp_file = output_file.parent / f"{output_file.name}.tmp.{uuid.uuid4().hex[:8]}"
-        
+        temp_file = (
+            output_file.parent /
+            f"{output_file.name}.tmp.{uuid.uuid4().hex[:8]}"
+        )
+
         try:
             # Generate the complete report content
             report_content = self._generate_report_content(indicators)
-            
+
             # Write to temporary file first
-            with temp_file.open('w', encoding='utf-8') as f:
+            with temp_file.open("w", encoding="utf-8") as f:
                 f.write(report_content)
                 f.flush()  # Ensure all content is written to disk
-            
+
             # Atomically move temporary file to final destination
             temp_file.rename(output_file)
-            
+
         except Exception as e:
             # Clean up temporary file if it exists
             if temp_file.exists():
@@ -1104,30 +1168,30 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
                 except OSError:
                     pass  # Ignore cleanup errors
             raise IOError(f"Failed to generate report: {e}") from e
-    
+
     def _generate_report_content(self, indicators: List[str]) -> str:
         """Generate the complete report content for the given indicators."""
         results = self.batch_score(indicators)
-        
+
         # Generate timestamp
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        
+
         # Build report content
         content_parts = []
         content_parts.append("# Feasibility Assessment Report")
         content_parts.append(f"Generated on: {timestamp}")
         content_parts.append(f"Total indicators analyzed: {len(indicators)}")
         content_parts.append("")
-        
+
         # Summary statistics
         scores = [result.feasibility_score for result in results]
         avg_score = sum(scores) / len(scores) if scores else 0
-        
+
         tier_counts = {}
         for result in results:
             tier = result.quality_tier
             tier_counts[tier] = tier_counts.get(tier, 0) + 1
-        
+
         content_parts.append("## Summary")
         content_parts.append(f"Average feasibility score: {avg_score:.3f}")
         content_parts.append("Quality tier distribution:")
@@ -1135,94 +1199,118 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
             percentage = (count / len(results)) * 100
             content_parts.append(f"  - {tier}: {count} ({percentage:.1f}%)")
         content_parts.append("")
-        
+
         # Detailed results
         content_parts.append("## Detailed Analysis")
         content_parts.append("")
-        
+
         # Sort results by score (highest first)
         sorted_results = list(zip(indicators, results))
         sorted_results.sort(key=lambda x: x[1].feasibility_score, reverse=True)
-        
+
         for i, (indicator, result) in enumerate(sorted_results, 1):
             content_parts.append(f"### {i}. Indicator Analysis")
             content_parts.append(f"**Text:** {indicator}")
             content_parts.append(f"**Score:** {result.feasibility_score:.3f}")
             content_parts.append(f"**Quality Tier:** {result.quality_tier}")
-            content_parts.append(f"**Quantitative Baseline:** {'Yes' if result.has_quantitative_baseline else 'No'}")
-            content_parts.append(f"**Quantitative Target:** {'Yes' if result.has_quantitative_target else 'No'}")
-            
+            content_parts.append(
+                f"**Quantitative Baseline:** {'Yes' if result.has_quantitative_baseline else 'No'}"
+            )
+            content_parts.append(
+                f"**Quantitative Target:** {'Yes' if result.has_quantitative_target else 'No'}"
+            )
+
             if result.components_detected:
-                content_parts.append(f"**Components Detected:** {', '.join(c.value for c in result.components_detected)}")
-            
+                content_parts.append(
+                    f"**Components Detected:** {', '.join(c.value for c in result.components_detected)}"
+                )
+
             if result.detailed_matches:
                 content_parts.append("**Pattern Matches:**")
                 for match in result.detailed_matches:
-                    content_parts.append(f"  - {match.component_type.value}: '{match.matched_text}' (confidence: {match.confidence:.2f})")
-            
+                    content_parts.append(
+                        f"  - {match.component_type.value}: '{match.matched_text}' (confidence: {match.confidence:.2f})"
+                    )
+
             content_parts.append("")
-        
+
         # Recommendations
         content_parts.append("## Recommendations")
-        
-        low_quality_count = sum(1 for result in results if result.feasibility_score < 0.5)
+
+        low_quality_count = sum(
+            1 for result in results if result.feasibility_score < 0.5
+        )
         if low_quality_count > 0:
-            content_parts.append(f"- {low_quality_count} indicators have scores below 0.5 and need improvement")
-            content_parts.append("- Focus on adding quantitative baselines and targets")
-            content_parts.append("- Include specific time horizons where missing")
-        
-        insufficient_count = sum(1 for result in results if result.quality_tier == 'insufficient')
+            content_parts.append(
+                f"- {low_quality_count} indicators have scores below 0.5 and need improvement"
+            )
+            content_parts.append(
+                "- Focus on adding quantitative baselines and targets")
+            content_parts.append(
+                "- Include specific time horizons where missing")
+
+        insufficient_count = sum(
+            1 for result in results if result.quality_tier == "insufficient"
+        )
         if insufficient_count > 0:
-            content_parts.append(f"- {insufficient_count} indicators are missing core components (baseline or target)")
-            content_parts.append("- These require fundamental restructuring to be measurable")
-        
+            content_parts.append(
+                f"- {insufficient_count} indicators are missing core components (baseline or target)"
+            )
+            content_parts.append(
+                "- These require fundamental restructuring to be measurable"
+            )
+
         content_parts.append("")
         content_parts.append("---")
         content_parts.append("*Report generated by Feasibility Scorer v1.0*")
-        
+
         return "\n".join(content_parts)
 
-    def generate_traceability_matrix_csv(self, results: Dict[str, IndicatorScore], output_dir: str = ".") -> str:
+    def generate_traceability_matrix_csv(
+        self, results: Dict[str, IndicatorScore], output_dir: str = "."
+    ) -> str:
         """
         Generate consolidated traceability matrix CSV with all evaluation dimensions.
-        
+
         Args:
             results: Dictionary mapping plan filenames to IndicatorScore objects
             output_dir: Directory to save the CSV file
-            
+
         Returns:
             Path to the generated CSV file
-            
+
         Raises:
             ImportError: If pandas is not available
         """
         if not PANDAS_AVAILABLE:
             # Fallback: generate CSV manually without pandas
             return self._generate_csv_fallback(results, output_dir)
-        
+
         # Spanish column headers for the traceability matrix
         columns = {
-            'archivo_plan': 'Archivo del Plan',
-            'puntuacion_factibilidad': 'Puntuación de Factibilidad',
-            'nivel_calidad': 'Nivel de Calidad',
-            'linea_base_cuantitativa': 'Línea Base Cuantitativa',
-            'meta_cuantitativa': 'Meta Cuantitativa',
-            'componentes_detectados': 'Componentes Detectados',
-            'tiene_linea_base': 'Tiene Línea Base',
-            'tiene_meta': 'Tiene Meta',
-            'tiene_horizonte_temporal': 'Tiene Horizonte Temporal',
-            'tiene_valores_numericos': 'Tiene Valores Numéricos',
-            'tiene_fechas': 'Tiene Fechas',
-            'coincidencias_detalladas': 'Coincidencias Detalladas',
-            'recomendacion_general': 'Recomendación General'
+            "archivo_plan": "Archivo del Plan",
+            "puntuacion_factibilidad": "Puntuación de Factibilidad",
+            "nivel_calidad": "Nivel de Calidad",
+            "linea_base_cuantitativa": "Línea Base Cuantitativa",
+            "meta_cuantitativa": "Meta Cuantitativa",
+            "componentes_detectados": "Componentes Detectados",
+            "tiene_linea_base": "Tiene Línea Base",
+            "tiene_meta": "Tiene Meta",
+            "tiene_horizonte_temporal": "Tiene Horizonte Temporal",
+            "tiene_valores_numericos": "Tiene Valores Numéricos",
+            "tiene_fechas": "Tiene Fechas",
+            "coincidencias_detalladas": "Coincidencias Detalladas",
+            "recomendacion_general": "Recomendación General",
         }
-        
+
         # Build rows for the DataFrame
         rows = []
         for plan_filename, score in results.items():
             # Generate overall recommendation based on quality tier
-            recommendation = FeasibilityScorer._get_recommendation_spanish(score.quality_tier)
-            
+            recommendation = FeasibilityScorer._get_recommendation_spanish(
+                score.quality_tier
+            )
+
             # Count component types
             components = score.components_detected
             has_baseline = ComponentType.BASELINE in components
@@ -1230,69 +1318,86 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
             has_time_horizon = ComponentType.TIME_HORIZON in components
             has_numerical = ComponentType.NUMERICAL in components
             has_dates = ComponentType.DATE in components
-            
+
             # Format detected components in Spanish
             component_names_spanish = {
-                ComponentType.BASELINE: 'línea base',
-                ComponentType.TARGET: 'meta',
-                ComponentType.TIME_HORIZON: 'horizonte temporal',
-                ComponentType.NUMERICAL: 'valores numéricos',
-                ComponentType.DATE: 'fechas'
+                ComponentType.BASELINE: "línea base",
+                ComponentType.TARGET: "meta",
+                ComponentType.TIME_HORIZON: "horizonte temporal",
+                ComponentType.NUMERICAL: "valores numéricos",
+                ComponentType.DATE: "fechas",
             }
-            
-            components_list = [component_names_spanish.get(comp, comp.value) for comp in components]
-            components_str = ', '.join(components_list) if components_list else 'ninguno'
-            
+
+            components_list = [
+                component_names_spanish.get(comp, comp.value) for comp in components
+            ]
+            components_str = (
+                ", ".join(components_list) if components_list else "ninguno"
+            )
+
             # Format detailed matches
             matches_details = []
             for match in score.detailed_matches:
                 match_info = f"{component_names_spanish.get(match.component_type, match.component_type.value)}: '{match.matched_text}' (confianza: {match.confidence:.2f})"
                 matches_details.append(match_info)
-            matches_str = '; '.join(matches_details) if matches_details else 'ninguna coincidencia'
-            
+            matches_str = (
+                "; ".join(matches_details)
+                if matches_details
+                else "ninguna coincidencia"
+            )
+
             row = {
-                'archivo_plan': plan_filename,
-                'puntuacion_factibilidad': round(score.feasibility_score, 3),
-                'nivel_calidad': FeasibilityScorer._translate_quality_tier_spanish(score.quality_tier),
-                'linea_base_cuantitativa': 'Sí' if score.has_quantitative_baseline else 'No',
-                'meta_cuantitativa': 'Sí' if score.has_quantitative_target else 'No',
-                'componentes_detectados': components_str,
-                'tiene_linea_base': 'Sí' if has_baseline else 'No',
-                'tiene_meta': 'Sí' if has_target else 'No',
-                'tiene_horizonte_temporal': 'Sí' if has_time_horizon else 'No',
-                'tiene_valores_numericos': 'Sí' if has_numerical else 'No',
-                'tiene_fechas': 'Sí' if has_dates else 'No',
-                'coincidencias_detalladas': matches_str,
-                'recomendacion_general': recommendation
+                "archivo_plan": plan_filename,
+                "puntuacion_factibilidad": round(score.feasibility_score, 3),
+                "nivel_calidad": FeasibilityScorer._translate_quality_tier_spanish(
+                    score.quality_tier
+                ),
+                "linea_base_cuantitativa": (
+                    "Sí" if score.has_quantitative_baseline else "No"
+                ),
+                "meta_cuantitativa": "Sí" if score.has_quantitative_target else "No",
+                "componentes_detectados": components_str,
+                "tiene_linea_base": "Sí" if has_baseline else "No",
+                "tiene_meta": "Sí" if has_target else "No",
+                "tiene_horizonte_temporal": "Sí" if has_time_horizon else "No",
+                "tiene_valores_numericos": "Sí" if has_numerical else "No",
+                "tiene_fechas": "Sí" if has_dates else "No",
+                "coincidencias_detalladas": matches_str,
+                "recomendacion_general": recommendation,
             }
             rows.append(row)
-        
+
         # Create DataFrame with Spanish column names
         df = pd.DataFrame(rows)
         df = df.rename(columns=columns)
-        
+
         # Sort by feasibility score (descending)
-        df = df.sort_values('Puntuación de Factibilidad', ascending=False)
-        
+        df = df.sort_values("Puntuación de Factibilidad", ascending=False)
+
         # Generate output filename
         output_path = Path(output_dir) / "matriz_trazabilidad_factibilidad.csv"
-        
+
         # Check if we need gzip compression
-        csv_content = df.to_csv(index=False, encoding='utf-8-sig')  # utf-8-sig for Excel compatibility
-        file_size_mb = len(csv_content.encode('utf-8')) / (1024 * 1024)
-        
+        csv_content = df.to_csv(
+            index=False, encoding="utf-8-sig"
+        )  # utf-8-sig for Excel compatibility
+        file_size_mb = len(csv_content.encode("utf-8")) / (1024 * 1024)
+
         if file_size_mb > 5.0:  # Compress if larger than 5MB
-            output_path = output_path.with_suffix('.csv.gz')
-            with gzip.open(output_path, 'wt', encoding='utf-8-sig') as f:
+            output_path = output_path.with_suffix(".csv.gz")
+            with gzip.open(output_path, "wt", encoding="utf-8-sig") as f:
                 f.write(csv_content)
-            print(f"CSV exportado con compresión gzip: {output_path} (tamaño original: {file_size_mb:.1f}MB)")
+            print(
+                f"CSV exportado con compresión gzip: {output_path} (tamaño original: {file_size_mb:.1f}MB)"
+            )
         else:
-            with open(output_path, 'w', encoding='utf-8-sig', newline='') as f:
+            with open(output_path, "w", encoding="utf-8-sig", newline="") as f:
                 f.write(csv_content)
-            print(f"CSV exportado: {output_path} (tamaño: {file_size_mb:.1f}MB)")
-        
+            print(
+                f"CSV exportado: {output_path} (tamaño: {file_size_mb:.1f}MB)")
+
         return str(output_path)
-    
+
     @staticmethod
     def translate_quality_tier_spanish(tier: str) -> str:
         """Public wrapper to translate quality tier to Spanish."""
@@ -1307,11 +1412,11 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
     def _translate_quality_tier_spanish(tier: str) -> str:
         """Translate quality tier to Spanish."""
         translations = {
-            'high': 'Alto',
-            'medium': 'Medio',
-            'low': 'Bajo',
-            'poor': 'Deficiente',
-            'insufficient': 'Insuficiente'
+            "high": "Alto",
+            "medium": "Medio",
+            "low": "Bajo",
+            "poor": "Deficiente",
+            "insufficient": "Insuficiente",
         }
         return translations.get(tier, tier)
 
@@ -1319,51 +1424,55 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
     def _get_recommendation_spanish(quality_tier: str) -> str:
         """Generate recommendation in Spanish based on quality tier."""
         recommendations = {
-            'high': 'Indicador de alta calidad. Mantener el nivel de especificidad.',
-            'medium': 'Indicador aceptable. Considerar agregar elementos cuantitativos adicionales.',
-            'low': 'Indicador básico. Requiere mejoras en elementos cuantitativos y horizonte temporal.',
-            'poor': 'Indicador deficiente. Necesita revisión integral para incluir línea base y metas claras.',
-            'insufficient': 'Indicador insuficiente. Debe incluir tanto línea base como metas para ser viable.'
+            "high": "Indicador de alta calidad. Mantener el nivel de especificidad.",
+            "medium": "Indicador aceptable. Considerar agregar elementos cuantitativos adicionales.",
+            "low": "Indicador básico. Requiere mejoras en elementos cuantitativos y horizonte temporal.",
+            "poor": "Indicador deficiente. Necesita revisión integral para incluir línea base y metas claras.",
+            "insufficient": "Indicador insuficiente. Debe incluir tanto línea base como metas para ser viable.",
         }
-        return recommendations.get(quality_tier, 'Evaluación pendiente.')
-    
+        return recommendations.get(quality_tier, "Evaluación pendiente.")
+
     @staticmethod
-    def _generate_csv_fallback(results: Dict[str, IndicatorScore], output_dir: str = ".") -> str:
+    def _generate_csv_fallback(
+        results: Dict[str, IndicatorScore], output_dir: str = "."
+    ) -> str:
         """
         Fallback CSV generation without pandas dependency.
-        
+
         Args:
             results: Dictionary mapping plan filenames to IndicatorScore objects
             output_dir: Directory to save the CSV file
-            
+
         Returns:
             Path to the generated CSV file
         """
         import csv
-        
+
         # CSV headers in Spanish
         headers = [
-            'Archivo del Plan',
-            'Puntuación de Factibilidad', 
-            'Nivel de Calidad',
-            'Línea Base Cuantitativa',
-            'Meta Cuantitativa',
-            'Componentes Detectados',
-            'Tiene Línea Base',
-            'Tiene Meta',
-            'Tiene Horizonte Temporal',
-            'Tiene Valores Numéricos',
-            'Tiene Fechas',
-            'Coincidencias Detalladas',
-            'Recomendación General'
+            "Archivo del Plan",
+            "Puntuación de Factibilidad",
+            "Nivel de Calidad",
+            "Línea Base Cuantitativa",
+            "Meta Cuantitativa",
+            "Componentes Detectados",
+            "Tiene Línea Base",
+            "Tiene Meta",
+            "Tiene Horizonte Temporal",
+            "Tiene Valores Numéricos",
+            "Tiene Fechas",
+            "Coincidencias Detalladas",
+            "Recomendación General",
         ]
-        
+
         # Generate rows
         rows = []
         for plan_filename, score in results.items():
             # Generate overall recommendation based on quality tier
-            recommendation = FeasibilityScorer._get_recommendation_spanish(score.quality_tier)
-            
+            recommendation = FeasibilityScorer._get_recommendation_spanish(
+                score.quality_tier
+            )
+
             # Count component types
             components = score.components_detected
             has_baseline = ComponentType.BASELINE in components
@@ -1371,79 +1480,92 @@ The feasibility scorer evaluates indicator quality by detecting three core compo
             has_time_horizon = ComponentType.TIME_HORIZON in components
             has_numerical = ComponentType.NUMERICAL in components
             has_dates = ComponentType.DATE in components
-            
+
             # Format detected components in Spanish
             component_names_spanish = {
-                ComponentType.BASELINE: 'línea base',
-                ComponentType.TARGET: 'meta',
-                ComponentType.TIME_HORIZON: 'horizonte temporal',
-                ComponentType.NUMERICAL: 'valores numéricos',
-                ComponentType.DATE: 'fechas'
+                ComponentType.BASELINE: "línea base",
+                ComponentType.TARGET: "meta",
+                ComponentType.TIME_HORIZON: "horizonte temporal",
+                ComponentType.NUMERICAL: "valores numéricos",
+                ComponentType.DATE: "fechas",
             }
-            
-            components_list = [component_names_spanish.get(comp, comp.value) for comp in components]
-            components_str = ', '.join(components_list) if components_list else 'ninguno'
-            
+
+            components_list = [
+                component_names_spanish.get(comp, comp.value) for comp in components
+            ]
+            components_str = (
+                ", ".join(components_list) if components_list else "ninguno"
+            )
+
             # Format detailed matches
             matches_details = []
             for match in score.detailed_matches:
                 match_info = f"{component_names_spanish.get(match.component_type, match.component_type.value)}: '{match.matched_text}' (confianza: {match.confidence:.2f})"
                 matches_details.append(match_info)
-            matches_str = '; '.join(matches_details) if matches_details else 'ninguna coincidencia'
-            
+            matches_str = (
+                "; ".join(matches_details)
+                if matches_details
+                else "ninguna coincidencia"
+            )
+
             row = [
                 plan_filename,
                 f"{score.feasibility_score:.3f}",
-                FeasibilityScorer._translate_quality_tier_spanish(score.quality_tier),
-                'Sí' if score.has_quantitative_baseline else 'No',
-                'Sí' if score.has_quantitative_target else 'No',
+                FeasibilityScorer._translate_quality_tier_spanish(
+                    score.quality_tier),
+                "Sí" if score.has_quantitative_baseline else "No",
+                "Sí" if score.has_quantitative_target else "No",
                 components_str,
-                'Sí' if has_baseline else 'No',
-                'Sí' if has_target else 'No',
-                'Sí' if has_time_horizon else 'No',
-                'Sí' if has_numerical else 'No',
-                'Sí' if has_dates else 'No',
+                "Sí" if has_baseline else "No",
+                "Sí" if has_target else "No",
+                "Sí" if has_time_horizon else "No",
+                "Sí" if has_numerical else "No",
+                "Sí" if has_dates else "No",
                 matches_str,
-                recommendation
+                recommendation,
             ]
-            rows.append((score.feasibility_score, row))  # Include score for sorting
-        
+            # Include score for sorting
+            rows.append((score.feasibility_score, row))
+
         # Sort by feasibility score (descending)
         rows.sort(key=lambda x: x[0], reverse=True)
         sorted_rows = [row[1] for row in rows]
-        
+
         # Generate output filename
         output_path = Path(output_dir) / "matriz_trazabilidad_factibilidad.csv"
-        
+
         # Write CSV and check size for compression
-        with open(output_path, 'w', encoding='utf-8-sig', newline='') as f:
+        with open(output_path, "w", encoding="utf-8-sig", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(headers)
             writer.writerows(sorted_rows)
-        
+
         # Check file size for compression
         file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
-        
+
         if file_size_mb > 5.0:  # Compress if larger than 5MB
-            compressed_path = output_path.with_suffix('.csv.gz')
-            with open(output_path, 'rb') as f_in:
-                with gzip.open(compressed_path, 'wb') as f_out:
+            compressed_path = output_path.with_suffix(".csv.gz")
+            with open(output_path, "rb") as f_in:
+                with gzip.open(compressed_path, "wb") as f_out:
                     f_out.write(f_in.read())
-            
+
             # Remove uncompressed file
             output_path.unlink()
-            
-            print(f"CSV exportado con compresión gzip: {compressed_path} (tamaño original: {file_size_mb:.1f}MB)")
+
+            print(
+                f"CSV exportado con compresión gzip: {compressed_path} (tamaño original: {file_size_mb:.1f}MB)"
+            )
             return str(compressed_path)
         else:
-            print(f"CSV exportado: {output_path} (tamaño: {file_size_mb:.1f}MB)")
+            print(
+                f"CSV exportado: {output_path} (tamaño: {file_size_mb:.1f}MB)")
             return str(output_path)
 
 
 def main():
     """Command-line interface for the Feasibility Scorer."""
     parser = argparse.ArgumentParser(
-        description='Feasibility Scorer - Evaluate indicator quality based on baseline, targets, and time horizons',
+        description="Feasibility Scorer - Evaluate indicator quality based on baseline, targets, and time horizons",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -1455,210 +1577,237 @@ Examples:
   
   # Process batch from file
   python feasibility_scorer.py --batch-file indicators.txt --export-csv
-        """
+        """,
     )
-    
+
     # Input options
     input_group = parser.add_mutually_exclusive_group(required=True)
     input_group.add_argument(
-        '--text',
-        type=str,
-        help='Single indicator text to evaluate'
+        "--text", type=str, help="Single indicator text to evaluate"
     )
     input_group.add_argument(
-        '--batch-file',
+        "--batch-file",
         type=str,
-        help='Path to file containing multiple indicators (one per line)'
+        help="Path to file containing multiple indicators (one per line)",
     )
     input_group.add_argument(
-        '--demo',
-        action='store_true',
-        help='Run demonstration with built-in examples'
+        "--demo", action="store_true", help="Run demonstration with built-in examples"
     )
-    
+
     # Output options
     parser.add_argument(
-        '--output-dir',
+        "--output-dir",
         type=str,
-        default='.',
-        help='Output directory for reports (default: current directory)'
+        default=".",
+        help="Output directory for reports (default: current directory)",
     )
     parser.add_argument(
-        '--export-csv',
-        action='store_true',
-        help='Generate consolidated traceability matrix CSV file'
+        "--export-csv",
+        action="store_true",
+        help="Generate consolidated traceability matrix CSV file",
     )
     parser.add_argument(
-        '--export-json',
-        action='store_true',
-        help='Export detailed results as JSON'
+        "--export-json", action="store_true", help="Export detailed results as JSON"
     )
     parser.add_argument(
-        '--export-markdown',
-        action='store_true',
-        help='Export results as Markdown report'
+        "--export-markdown",
+        action="store_true",
+        help="Export results as Markdown report",
     )
     parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Show detailed component matches'
+        "--verbose", action="store_true", help="Show detailed component matches"
     )
-    
+
     args = parser.parse_args()
-    
+
     # Ensure output directory exists
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     scorer = FeasibilityScorer()
     results = {}
-    
+
     if args.demo:
         # Run built-in demonstration
         demo_indicators = {
-            'ejemplo_alta_calidad.txt': 'Incrementar la línea base de 65% de cobertura educativa a una meta de 85% para el año 2025',
-            'ejemplo_calidad_media.txt': 'Mejorar desde la situación inicial hasta el objetivo propuesto con incremento del 20%',
-            'ejemplo_calidad_baja.txt': 'Partir de la línea base para alcanzar el objetivo',
-            'ejemplo_insuficiente.txt': 'Aumentar el acceso a servicios de salud en la región'
+            "ejemplo_alta_calidad.txt": "Incrementar la línea base de 65% de cobertura educativa a una meta de 85% para el año 2025",
+            "ejemplo_calidad_media.txt": "Mejorar desde la situación inicial hasta el objetivo propuesto con incremento del 20%",
+            "ejemplo_calidad_baja.txt": "Partir de la línea base para alcanzar el objetivo",
+            "ejemplo_insuficiente.txt": "Aumentar el acceso a servicios de salud en la región",
         }
-        
+
         print("DEMOSTRACIÓN - Feasibility Scorer")
         print("=" * 50)
-        
+
         for filename, text in demo_indicators.items():
             score = scorer.calculate_feasibility_score(text)
             results[filename] = score
-            
+
             print(f"\nArchivo: {filename}")
             print(f"Texto: {text}")
             print(f"Puntuación: {score.feasibility_score:.3f}")
-            print(f"Nivel: {scorer.translate_quality_tier_spanish(score.quality_tier)}")
-            print(f"Recomendación: {scorer.get_recommendation_spanish(score.quality_tier)}")
-            
+            print(
+                f"Nivel: {scorer.translate_quality_tier_spanish(score.quality_tier)}")
+            print(
+                f"Recomendación: {scorer.get_recommendation_spanish(score.quality_tier)}"
+            )
+
             if args.verbose:
-                print(f"Componentes: {[c.value for c in score.components_detected]}")
+                print(
+                    f"Componentes: {[c.value for c in score.components_detected]}")
                 if score.detailed_matches:
                     print("Coincidencias detalladas:")
                     for match in score.detailed_matches:
-                        print(f"  - {match.component_type.value}: '{match.matched_text}' (confianza: {match.confidence:.2f})")
-    
+                        print(
+                            f"  - {match.component_type.value}: '{match.matched_text}' (confianza: {match.confidence:.2f})"
+                        )
+
     elif args.text:
         # Single text evaluation
         filename = "input_text.txt"
         score = scorer.calculate_feasibility_score(args.text)
         results[filename] = score
-        
+
         print(f"Texto evaluado: {args.text}")
         print(f"Puntuación de factibilidad: {score.feasibility_score:.3f}")
-        print(f"Nivel de calidad: {scorer.translate_quality_tier_spanish(score.quality_tier)}")
-        print(f"Línea base cuantitativa: {'Sí' if score.has_quantitative_baseline else 'No'}")
-        print(f"Meta cuantitativa: {'Sí' if score.has_quantitative_target else 'No'}")
-        print(f"Recomendación: {scorer.get_recommendation_spanish(score.quality_tier)}")
-        
+        print(
+            f"Nivel de calidad: {scorer.translate_quality_tier_spanish(score.quality_tier)}"
+        )
+        print(
+            f"Línea base cuantitativa: {'Sí' if score.has_quantitative_baseline else 'No'}"
+        )
+        print(
+            f"Meta cuantitativa: {'Sí' if score.has_quantitative_target else 'No'}")
+        print(
+            f"Recomendación: {scorer.get_recommendation_spanish(score.quality_tier)}")
+
         if args.verbose and score.detailed_matches:
             print("\nCoincidencias detalladas:")
             for match in score.detailed_matches:
-                print(f"  - {match.component_type.value}: '{match.matched_text}' (confianza: {match.confidence:.2f})")
-    
+                print(
+                    f"  - {match.component_type.value}: '{match.matched_text}' (confianza: {match.confidence:.2f})"
+                )
+
     elif args.batch_file:
         # Batch processing from file
         batch_path = Path(args.batch_file)
         if not batch_path.exists():
             print(f"Error: El archivo {args.batch_file} no existe.")
             return 1
-        
-        with open(batch_path, 'r', encoding='utf-8') as f:
+
+        with open(batch_path, "r", encoding="utf-8") as f:
             indicators = [line.strip() for line in f if line.strip()]
-        
-        print(f"Procesando {len(indicators)} indicadores desde {args.batch_file}...")
-        
+
+        print(
+            f"Procesando {len(indicators)} indicadores desde {args.batch_file}...")
+
         for i, indicator in enumerate(indicators, 1):
             filename = f"indicador_{i:03d}.txt"
             score = scorer.calculate_feasibility_score(indicator)
             results[filename] = score
-            
+
             if not args.export_csv:  # Only show individual results if not exporting CSV
                 print(f"\n{i}. {filename}")
                 print(f"   Puntuación: {score.feasibility_score:.3f}")
-                print(f"   Nivel: {scorer.translate_quality_tier_spanish(score.quality_tier)}")
-    
+                print(
+                    f"   Nivel: {scorer.translate_quality_tier_spanish(score.quality_tier)}"
+                )
+
     # Export results in requested formats
     if args.export_csv:
         try:
-            csv_path = scorer.generate_traceability_matrix_csv(results, str(output_dir))
+            csv_path = scorer.generate_traceability_matrix_csv(
+                results, str(output_dir))
             print(f"✓ Matriz de trazabilidad CSV generada: {csv_path}")
         except ImportError as e:
             print(f"Error: {e}")
             print("Instalar pandas con: pip install pandas")
             return 1
-    
+
     if args.export_json:
         json_path = output_dir / "resultados_factibilidad.json"
         json_data = {}
         for filename, score in results.items():
             json_data[filename] = {
-                'feasibility_score': score.feasibility_score,
-                'quality_tier': score.quality_tier,
-                'components_detected': [c.value for c in score.components_detected],
-                'has_quantitative_baseline': score.has_quantitative_baseline,
-                'has_quantitative_target': score.has_quantitative_target,
-                'detailed_matches': [
+                "feasibility_score": score.feasibility_score,
+                "quality_tier": score.quality_tier,
+                "components_detected": [c.value for c in score.components_detected],
+                "has_quantitative_baseline": score.has_quantitative_baseline,
+                "has_quantitative_target": score.has_quantitative_target,
+                "detailed_matches": [
                     {
-                        'component_type': match.component_type.value,
-                        'matched_text': match.matched_text,
-                        'confidence': match.confidence,
-                        'position': match.position
+                        "component_type": match.component_type.value,
+                        "matched_text": match.matched_text,
+                        "confidence": match.confidence,
+                        "position": match.position,
                     }
                     for match in score.detailed_matches
-                ]
+                ],
             }
-        
-        with open(json_path, 'w', encoding='utf-8') as f:
+
+        with open(json_path, "w", encoding="utf-8") as f:
             json.dump(json_data, f, indent=2, ensure_ascii=False)
         print(f"✓ Resultados JSON exportados: {json_path}")
-    
+
     if args.export_markdown:
         md_path = output_dir / "reporte_factibilidad.md"
-        with open(md_path, 'w', encoding='utf-8') as f:
+        with open(md_path, "w", encoding="utf-8") as f:
             f.write("# Reporte de Evaluación de Factibilidad de Indicadores\n\n")
-            f.write(f"**Fecha de generación:** {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
-            f.write(f"**Número total de indicadores evaluados:** {len(results)}\n\n")
-            
+            f.write(
+                f"**Fecha de generación:** {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            )
+            f.write(
+                f"**Número total de indicadores evaluados:** {len(results)}\n\n")
+
             # Summary statistics
             scores = [score.feasibility_score for score in results.values()]
             tiers = [score.quality_tier for score in results.values()]
-            
+
             f.write("## Resumen Estadístico\n\n")
             if scores:
-                f.write(f"- **Puntuación promedio:** {sum(scores)/len(scores):.3f}\n")
+                f.write(
+                    f"- **Puntuación promedio:** {sum(scores) / len(scores):.3f}\n")
                 f.write(f"- **Puntuación máxima:** {max(scores):.3f}\n")
                 f.write(f"- **Puntuación mínima:** {min(scores):.3f}\n")
-                
+
                 tier_counts = {tier: tiers.count(tier) for tier in set(tiers)}
                 f.write(f"\n### Distribución por Nivel de Calidad\n\n")
                 for tier, count in tier_counts.items():
                     tier_spanish = scorer.translate_quality_tier_spanish(tier)
                     percentage = (count / len(tiers)) * 100
-                    f.write(f"- **{tier_spanish}:** {count} indicadores ({percentage:.1f}%)\n")
-            
+                    f.write(
+                        f"- **{tier_spanish}:** {count} indicadores ({percentage:.1f}%)\n"
+                    )
+
             f.write("\n## Resultados Detallados\n\n")
-            
+
             # Sort results by score
-            sorted_results = sorted(results.items(), key=lambda x: x[1].feasibility_score, reverse=True)
-            
+            sorted_results = sorted(
+                results.items(), key=lambda x: x[1].feasibility_score, reverse=True
+            )
+
             for filename, score in sorted_results:
                 f.write(f"### {filename}\n\n")
                 f.write(f"- **Puntuación:** {score.feasibility_score:.3f}\n")
-                f.write(f"- **Nivel de calidad:** {scorer.translate_quality_tier_spanish(score.quality_tier)}\n")
-                f.write(f"- **Línea base cuantitativa:** {'Sí' if score.has_quantitative_baseline else 'No'}\n")
-                f.write(f"- **Meta cuantitativa:** {'Sí' if score.has_quantitative_target else 'No'}\n")
-                f.write(f"- **Componentes detectados:** {len(score.components_detected)}\n")
-                f.write(f"- **Recomendación:** {scorer.get_recommendation_spanish(score.quality_tier)}\n\n")
-        
-        print(f"✓ Reporte Markdown exportado: {md_path}")
-    
-    return 0
+                f.write(
+                    f"- **Nivel de calidad:** {scorer.translate_quality_tier_spanish(score.quality_tier)}\n"
+                )
+                f.write(
+                    f"- **Línea base cuantitativa:** {'Sí' if score.has_quantitative_baseline else 'No'}\n"
+                )
+                f.write(
+                    f"- **Meta cuantitativa:** {'Sí' if score.has_quantitative_target else 'No'}\n"
+                )
+                f.write(
+                    f"- **Componentes detectados:** {len(score.components_detected)}\n"
+                )
+                f.write(
+                    f"- **Recomendación:** {scorer.get_recommendation_spanish(score.quality_tier)}\n\n"
+                )
 
+        print(f"✓ Reporte Markdown exportado: {md_path}")
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/pdm_contra/bridges/decatalogo_provider.py
+++ b/pdm_contra/bridges/decatalogo_provider.py
@@ -2,6 +2,7 @@
 """Proveedor centralizado de decálogos canónicos."""
 
 from __future__ import annotations
+
 from pathlib import Path
 from typing import Dict, List
 

--- a/plan_sanitizer.py
+++ b/plan_sanitizer.py
@@ -7,192 +7,265 @@ This module provides functions to:
 3. Maintain Spanish tilded versions only in Markdown display text
 """
 
-import re
 import os
-from typing import Dict, Any
+import re
+from typing import Any, Dict
 
 
 class PlanSanitizer:
     """Handles plan name sanitization and JSON key standardization."""
-    
+
     # Characters that are invalid for filenames on various operating systems
     INVALID_CHARS = {
         # Windows forbidden characters
-        '<', '>', ':', '"', '/', '\\', '|', '?', '*',
+        "<",
+        ">",
+        ":",
+        '"',
+        "/",
+        "\\",
+        "|",
+        "?",
+        "*",
         # Additional problematic characters
-        '\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
-        '\x08', '\x09', '\x0a', '\x0b', '\x0c', '\x0d', '\x0e', '\x0f',
-        '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
-        '\x18', '\x19', '\x1a', '\x1b', '\x1c', '\x1d', '\x1e', '\x1f',
+        "\x00",
+        "\x01",
+        "\x02",
+        "\x03",
+        "\x04",
+        "\x05",
+        "\x06",
+        "\x07",
+        "\x08",
+        "\x09",
+        "\x0a",
+        "\x0b",
+        "\x0c",
+        "\x0d",
+        "\x0e",
+        "\x0f",
+        "\x10",
+        "\x11",
+        "\x12",
+        "\x13",
+        "\x14",
+        "\x15",
+        "\x16",
+        "\x17",
+        "\x18",
+        "\x19",
+        "\x1a",
+        "\x1b",
+        "\x1c",
+        "\x1d",
+        "\x1e",
+        "\x1f",
     }
-    
+
     # Windows reserved names
     RESERVED_NAMES = {
-        'CON', 'PRN', 'AUX', 'NUL',
-        'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
-        'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9",
     }
-    
+
     # Mapping of Spanish characters with tildes to underscore versions for JSON keys
     JSON_KEY_REPLACEMENTS = {
-        'á': 'a', 'é': 'e', 'í': 'i', 'ó': 'o', 'ú': 'u',
-        'Á': 'A', 'É': 'E', 'Í': 'I', 'Ó': 'O', 'Ú': 'U',
-        'ñ': 'n', 'Ñ': 'N',
-        'ü': 'u', 'Ü': 'U',
+        "á": "a",
+        "é": "e",
+        "í": "i",
+        "ó": "o",
+        "ú": "u",
+        "Á": "A",
+        "É": "E",
+        "Í": "I",
+        "Ó": "O",
+        "Ú": "U",
+        "ñ": "n",
+        "Ñ": "N",
+        "ü": "u",
+        "Ü": "U",
         # Common Spanish combinations that need standardization
-        'línea': 'linea',
-        'número': 'numero', 
-        'página': 'pagina',
-        'evaluación': 'evaluacion',
-        'implementación': 'implementacion',
-        'identificación': 'identificacion',
-        'descripción': 'descripcion',
-        'situación': 'situacion',
-        'población': 'poblacion',
-        'duración': 'duracion',
-        'versión': 'version',
-        'creación': 'creacion',
-        'modificación': 'modificacion',
+        "línea": "linea",
+        "número": "numero",
+        "página": "pagina",
+        "evaluación": "evaluacion",
+        "implementación": "implementacion",
+        "identificación": "identificacion",
+        "descripción": "descripcion",
+        "situación": "situacion",
+        "población": "poblacion",
+        "duración": "duracion",
+        "versión": "version",
+        "creación": "creacion",
+        "modificación": "modificacion",
     }
 
     @staticmethod
     def sanitize_plan_name(plan_name: str, max_length: int = 255) -> str:
         """
         Sanitize a plan name for safe filesystem usage.
-        
+
         Args:
             plan_name: The original plan name to sanitize
             max_length: Maximum length for the sanitized name (default 255)
-            
+
         Returns:
             Sanitized plan name safe for filesystem usage
-            
+
         Examples:
             >>> PlanSanitizer.sanitize_plan_name("Plan: Meta/Objetivo 2024*")
             'Plan - Meta-Objetivo 2024'
-            
+
             >>> PlanSanitizer.sanitize_plan_name("Plan <importante>")
             'Plan (importante)'
         """
         if not plan_name or not plan_name.strip():
             return "plan_sin_nombre"
-        
+
         # Start with original name
         sanitized = plan_name.strip()
-        
+
         # Replace invalid characters with safe alternatives
         char_replacements = {
-            '/': '-',
-            '\\': '-', 
-            ':': ' - ',
-            '*': '',
-            '?': '',
+            "/": "-",
+            "\\": "-",
+            ":": " - ",
+            "*": "",
+            "?": "",
             '"': "'",
-            '<': '(',
-            '>': ')',
-            '|': '-',
-            '\t': ' ',
-            '\n': ' ',
-            '\r': ' ',
+            "<": "(",
+            ">": ")",
+            "|": "-",
+            "\t": " ",
+            "\n": " ",
+            "\r": " ",
         }
-        
+
         for invalid_char, replacement in char_replacements.items():
             sanitized = sanitized.replace(invalid_char, replacement)
-        
+
         # Remove any remaining invalid control characters
-        sanitized = ''.join(char for char in sanitized 
-                          if char not in PlanSanitizer.INVALID_CHARS)
-        
+        sanitized = "".join(
+            char for char in sanitized if char not in PlanSanitizer.INVALID_CHARS
+        )
+
         # Handle consecutive brackets - collapse multiple to single
-        sanitized = re.sub(r'\(+', '(', sanitized)
-        sanitized = re.sub(r'\)+', ')', sanitized)
-        
+        sanitized = re.sub(r"\(+", "(", sanitized)
+        sanitized = re.sub(r"\)+", ")", sanitized)
+
         # Normalize multiple spaces/dashes
-        sanitized = re.sub(r'\s+', ' ', sanitized)
-        sanitized = re.sub(r'-+', '-', sanitized)
+        sanitized = re.sub(r"\s+", " ", sanitized)
+        sanitized = re.sub(r"-+", "-", sanitized)
         # Keep spaces around dashes for readability unless at word boundaries
-        sanitized = re.sub(r'\s*-\s*', ' - ', sanitized)
-        sanitized = re.sub(r'^\s*-\s*', '', sanitized)  # Remove leading dash
-        sanitized = re.sub(r'\s*-\s*$', '', sanitized)  # Remove trailing dash
-        
+        sanitized = re.sub(r"\s*-\s*", " - ", sanitized)
+        sanitized = re.sub(r"^\s*-\s*", "", sanitized)  # Remove leading dash
+        sanitized = re.sub(r"\s*-\s*$", "", sanitized)  # Remove trailing dash
+
         # Remove leading/trailing spaces and dashes
-        sanitized = sanitized.strip(' -.')
-        
+        sanitized = sanitized.strip(" -.")
+
         # Handle reserved names
         base_name = sanitized.upper()
-        if base_name in PlanSanitizer.RESERVED_NAMES or base_name.split('.')[0] in PlanSanitizer.RESERVED_NAMES:
+        if (
+            base_name in PlanSanitizer.RESERVED_NAMES
+            or base_name.split(".")[0] in PlanSanitizer.RESERVED_NAMES
+        ):
             sanitized = f"plan_{sanitized}"
-        
+
         # Truncate if too long while preserving readability
         if len(sanitized) > max_length:
             # Try to truncate at word boundary
             truncated = sanitized[:max_length]
-            last_space = truncated.rfind(' ')
-            last_dash = truncated.rfind('-')
+            last_space = truncated.rfind(" ")
+            last_dash = truncated.rfind("-")
             cut_point = max(last_space, last_dash)
-            
-            if cut_point > max_length * 0.7:  # Only cut at boundary if it's not too short
+
+            if (
+                cut_point > max_length * 0.7
+            ):  # Only cut at boundary if it's not too short
                 sanitized = truncated[:cut_point]
             else:
                 sanitized = truncated
-            
-            sanitized = sanitized.rstrip(' -.')
-        
+
+            sanitized = sanitized.rstrip(" -.")
+
         # Ensure we have something after all processing
         if not sanitized:
             sanitized = "plan_sin_nombre"
-            
+
         return sanitized
 
     @staticmethod
-    def create_safe_directory(plan_name: str, base_path: str = ".", create: bool = True) -> str:
+    def create_safe_directory(
+        plan_name: str, base_path: str = ".", create: bool = True
+    ) -> str:
         """
         Create a safe directory name and optionally create the directory.
-        
+
         Args:
             plan_name: Original plan name
             base_path: Base path where directory should be created
             create: Whether to actually create the directory
-            
+
         Returns:
             Full path to the safe directory
         """
         sanitized_name = PlanSanitizer.sanitize_plan_name(plan_name)
         full_path = os.path.join(base_path, sanitized_name)
-        
+
         # Handle potential duplicates
         if os.path.exists(full_path):
             counter = 1
             while os.path.exists(f"{full_path}_{counter}"):
                 counter += 1
             full_path = f"{full_path}_{counter}"
-        
+
         if create:
             os.makedirs(full_path, exist_ok=True)
-            
+
         return full_path
 
     @staticmethod
     def standardize_json_key(key: str) -> str:
         """
         Convert a JSON key to standardized underscore format without tildes.
-        
+
         Args:
             key: Original key that may contain tildes or other characters
-            
+
         Returns:
             Standardized key with underscores and no tildes
-            
+
         Examples:
             >>> PlanSanitizer.standardize_json_key("línea_base")
             'linea_base'
-            
+
             >>> PlanSanitizer.standardize_json_key("númeroPágina")
             'numero_pagina'
         """
         if not key:
             return key
-        
+
         # First handle complete word replacements
         key_lower = key.lower()
         for spanish_word, english_word in PlanSanitizer.JSON_KEY_REPLACEMENTS.items():
@@ -201,51 +274,62 @@ class PlanSanitizer:
                 pattern = re.compile(re.escape(spanish_word), re.IGNORECASE)
                 key = pattern.sub(english_word, key)
                 key_lower = key.lower()
-        
+
         # Then handle individual character replacements
         for spanish_char, replacement in PlanSanitizer.JSON_KEY_REPLACEMENTS.items():
             if len(spanish_char) == 1:  # Only single character replacements
                 key = key.replace(spanish_char, replacement)
-        
+
         # Convert camelCase to snake_case
-        key = re.sub('([a-z0-9])([A-Z])', r'\1_\2', key)
-        
+        key = re.sub("([a-z0-9])([A-Z])", r"\1_\2", key)
+
         # Replace spaces and dashes with underscores
-        key = re.sub(r'[-\s]+', '_', key)
-        
+        key = re.sub(r"[-\s]+", "_", key)
+
         # Remove non-alphanumeric characters except underscores
         # But preserve letters that were converted from tildes
-        key = re.sub(r'[^a-zA-Z0-9_áéíóúñüÁÉÍÓÚÑÜ]', '', key)
-        
+        key = re.sub(r"[^a-zA-Z0-9_áéíóúñüÁÉÍÓÚÑÜ]", "", key)
+
         # Now handle any remaining tilded characters
         final_replacements = {
-            'á': 'a', 'é': 'e', 'í': 'i', 'ó': 'o', 'ú': 'u',
-            'Á': 'A', 'É': 'E', 'Í': 'I', 'Ó': 'O', 'Ú': 'U',
-            'ñ': 'n', 'Ñ': 'N', 'ü': 'u', 'Ü': 'U',
+            "á": "a",
+            "é": "e",
+            "í": "i",
+            "ó": "o",
+            "ú": "u",
+            "Á": "A",
+            "É": "E",
+            "Í": "I",
+            "Ó": "O",
+            "Ú": "U",
+            "ñ": "n",
+            "Ñ": "N",
+            "ü": "u",
+            "Ü": "U",
         }
         for tilded_char, replacement in final_replacements.items():
             key = key.replace(tilded_char, replacement)
-        
+
         # Normalize multiple underscores
-        key = re.sub(r'_+', '_', key)
-        
+        key = re.sub(r"_+", "_", key)
+
         # Remove leading/trailing underscores
-        key = key.strip('_')
-        
+        key = key.strip("_")
+
         # Ensure lowercase
         key = key.lower()
-        
+
         return key
 
     @staticmethod
     def standardize_json_object(obj: Any, preserve_display_keys: bool = True) -> Any:
         """
         Recursively standardize all keys in a JSON object/dictionary.
-        
+
         Args:
             obj: The object to standardize (dict, list, or primitive)
             preserve_display_keys: Whether to preserve original keys with "_display" suffix
-            
+
         Returns:
             Object with standardized keys
         """
@@ -253,58 +337,67 @@ class PlanSanitizer:
             standardized = {}
             for key, value in obj.items():
                 new_key = PlanSanitizer.standardize_json_key(key)
-                
+
                 # Preserve original key with tildes for display purposes if requested
-                if preserve_display_keys and new_key != key and any(
-                    char in key for char in 'áéíóúñüÁÉÍÓÚÑÜ'
+                if (
+                    preserve_display_keys
+                    and new_key != key
+                    and any(char in key for char in "áéíóúñüÁÉÍÓÚÑÜ")
                 ):
                     standardized[f"{new_key}_display"] = key
-                
+
                 # Recursively standardize the value
                 standardized[new_key] = PlanSanitizer.standardize_json_object(
                     value, preserve_display_keys
                 )
-                
+
             return standardized
         elif isinstance(obj, list):
-            return [PlanSanitizer.standardize_json_object(item, preserve_display_keys) 
-                    for item in obj]
+            return [
+                PlanSanitizer.standardize_json_object(
+                    item, preserve_display_keys)
+                for item in obj
+            ]
         else:
             return obj
 
     @staticmethod
-    def get_markdown_display_key(standardized_key: str, json_obj: Dict[str, Any]) -> str:
+    def get_markdown_display_key(
+        standardized_key: str, json_obj: Dict[str, Any]
+    ) -> str:
         """
         Get the tilded Spanish version for Markdown display from a standardized key.
-        
+
         Args:
-            standardized_key: The underscore key without tildes  
+            standardized_key: The underscore key without tildes
             json_obj: The JSON object that may contain display versions
-            
+
         Returns:
             Display version with tildes if available, otherwise the standardized key
         """
         display_key = f"{standardized_key}_display"
         if display_key in json_obj:
             return json_obj[display_key]
-        
+
         # Fallback: reverse lookup common patterns
         display_mappings = {
-            'linea_base': 'línea base',
-            'numero_pagina': 'número página', 
-            'evaluacion': 'evaluación',
-            'implementacion': 'implementación',
-            'identificacion': 'identificación',
-            'descripcion': 'descripción',
-            'situacion': 'situación',
-            'poblacion': 'población',
-            'duracion': 'duración',
-            'version': 'versión',
-            'creacion': 'creación',
-            'modificacion': 'modificación',
+            "linea_base": "línea base",
+            "numero_pagina": "número página",
+            "evaluacion": "evaluación",
+            "implementacion": "implementación",
+            "identificacion": "identificación",
+            "descripcion": "descripción",
+            "situacion": "situación",
+            "poblacion": "población",
+            "duracion": "duración",
+            "version": "versión",
+            "creacion": "creación",
+            "modificacion": "modificación",
         }
-        
-        return display_mappings.get(standardized_key, standardized_key.replace('_', ' '))
+
+        return display_mappings.get(
+            standardized_key, standardized_key.replace("_", " ")
+        )
 
 
 # Convenience functions for common use cases
@@ -313,7 +406,9 @@ def sanitize_plan_name(plan_name: str, max_length: int = 255) -> str:
     return PlanSanitizer.sanitize_plan_name(plan_name, max_length)
 
 
-def standardize_json_keys(json_obj: Dict[str, Any], preserve_display: bool = True) -> Dict[str, Any]:
+def standardize_json_keys(
+    json_obj: Dict[str, Any], preserve_display: bool = True
+) -> Dict[str, Any]:
     """Convenience function for JSON key standardization."""
     return PlanSanitizer.standardize_json_object(json_obj, preserve_display)
 

--- a/test_causal_pattern_detector.py
+++ b/test_causal_pattern_detector.py
@@ -12,6 +12,7 @@ Comprehensive test suite for the CausalPatternDetector class, including tests fo
 """
 
 import unittest
+
 from causal_pattern_detector import CausalPatternDetector
 
 
@@ -21,132 +22,162 @@ class TestCausalPatternDetector(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.detector = CausalPatternDetector()
-        
+
         # Test texts with new patterns
         self.test_texts = {
             # New pattern: implica
-            'implica_causal': 'El aumento de temperatura implica mayor evaporación del agua.',
-            'implica_logical': 'Esta ecuación implica que x debe ser positivo.',
-            'implica_negated': 'Esto no implica una relación causal directa.',
-            'implica_question': '¿Esto implica que debemos cambiar el plan?',
-            
+            "implica_causal": "El aumento de temperatura implica mayor evaporación del agua.",
+            "implica_logical": "Esta ecuación implica que x debe ser positivo.",
+            "implica_negated": "Esto no implica una relación causal directa.",
+            "implica_question": "¿Esto implica que debemos cambiar el plan?",
             # New pattern: conduce a
-            'conduce_causal': 'La falta de inversión conduce a la obsolescencia tecnológica.',
-            'conduce_variations': 'Este proceso conduce hacia mejores resultados.',
-            'conduce_conditional': 'Si seguimos así, podría conducir al fracaso.',
-            
+            "conduce_causal": "La falta de inversión conduce a la obsolescencia tecnológica.",
+            "conduce_variations": "Este proceso conduce hacia mejores resultados.",
+            "conduce_conditional": "Si seguimos así, podría conducir al fracaso.",
             # New pattern: mediante
-            'mediante_causal': 'La empresa redujo costos mediante la automatización.',
-            'mediante_instrumental': 'El análisis se realizó mediante una herramienta especializada.',
-            'mediante_method': 'La medición se efectúa mediante el método estándar.',
-            
+            "mediante_causal": "La empresa redujo costos mediante la automatización.",
+            "mediante_instrumental": "El análisis se realizó mediante una herramienta especializada.",
+            "mediante_method": "La medición se efectúa mediante el método estándar.",
             # New pattern: por medio de
-            'por_medio_causal': 'Se logró el objetivo por medio de la colaboración.',
-            'por_medio_instrumental': 'La técnica funciona por medio de la resonancia magnética.',
-            
+            "por_medio_causal": "Se logró el objetivo por medio de la colaboración.",
+            "por_medio_instrumental": "La técnica funciona por medio de la resonancia magnética.",
             # New pattern: tendencia a
-            'tendencia_causal': 'Los individuos muestran tendencia a repetir comportamientos exitosos.',
-            'tendencia_statistical': 'Los datos muestran una tendencia a la alza en los gráficos.',
-            'tendencia_correlation': 'La estadística revela tendencia a la correlación positiva.',
-            
+            "tendencia_causal": "Los individuos muestran tendencia a repetir comportamientos exitosos.",
+            "tendencia_statistical": "Los datos muestran una tendencia a la alza en los gráficos.",
+            "tendencia_correlation": "La estadística revela tendencia a la correlación positiva.",
             # Multiple patterns in one text
-            'multiple_patterns': '''
+            "multiple_patterns": """
             El cambio climático implica mayores riesgos ambientales. Esto conduce a 
             la necesidad de adaptación mediante nuevas tecnologías. Por medio de la 
             investigación observamos tendencia a mejores resultados.
-            ''',
-            
+            """,
             # Existing patterns for regression testing
-            'existing_porque': 'El proyecto falló porque no hubo suficiente financiación.',
-            'existing_debido': 'La demora se produjo debido a problemas técnicos.',
-            'existing_ya_que': 'Se canceló la reunión ya que no había quórum.'
+            "existing_porque": "El proyecto falló porque no hubo suficiente financiación.",
+            "existing_debido": "La demora se produjo debido a problemas técnicos.",
+            "existing_ya_que": "Se canceló la reunión ya que no había quórum.",
         }
 
     def test_new_pattern_implica_detection(self):
         """Test detection of 'implica' pattern with context awareness."""
         # Should detect causal usage with high confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['implica_causal'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["implica_causal"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'implica')
+        self.assertEqual(matches[0].connector, "implica")
         self.assertGreater(matches[0].confidence, 0.5)
-        
+
         # Should detect logical usage with lower confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['implica_logical'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["implica_logical"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertLess(matches[0].confidence, 0.5)  # Reduced due to mathematical context
-        
+        self.assertLess(
+            matches[0].confidence, 0.5
+        )  # Reduced due to mathematical context
+
         # Should detect negated usage with very low confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['implica_negated'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["implica_negated"]
+        )
         self.assertEqual(len(matches), 1)
         self.assertLess(matches[0].confidence, 0.3)  # Reduced due to negation
 
     def test_new_pattern_conduce_detection(self):
         """Test detection of 'conduce a' pattern and variations."""
-        matches = self.detector.detect_causal_patterns(self.test_texts['conduce_causal'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["conduce_causal"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'conduce a')
+        self.assertEqual(matches[0].connector, "conduce a")
         self.assertGreater(matches[0].confidence, 0.7)
-        
+
         # Test variations like "conduce hacia"
-        matches = self.detector.detect_causal_patterns(self.test_texts['conduce_variations'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["conduce_variations"]
+        )
         self.assertEqual(len(matches), 1)
 
     def test_new_pattern_mediante_detection(self):
         """Test detection of 'mediante' pattern with instrumental vs causal distinction."""
         # Causal usage should have moderate confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['mediante_causal'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["mediante_causal"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'mediante')
-        
+        self.assertEqual(matches[0].connector, "mediante")
+
         # Instrumental usage should have lower confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['mediante_instrumental'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["mediante_instrumental"]
+        )
         self.assertEqual(len(matches), 1)
         instrumental_confidence = matches[0].confidence
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['mediante_causal'])
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["mediante_causal"]
+        )
         causal_confidence = matches[0].confidence
-        
+
         # Causal usage should have higher confidence than instrumental
         self.assertGreater(causal_confidence, instrumental_confidence)
 
     def test_new_pattern_por_medio_detection(self):
         """Test detection of 'por medio de' pattern."""
-        matches = self.detector.detect_causal_patterns(self.test_texts['por_medio_causal'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["por_medio_causal"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'por medio de')
+        self.assertEqual(matches[0].connector, "por medio de")
         self.assertGreater(matches[0].confidence, 0.4)
-        
+
         # Should handle instrumental usage with appropriate confidence reduction
-        matches = self.detector.detect_causal_patterns(self.test_texts['por_medio_instrumental'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["por_medio_instrumental"]
+        )
         self.assertEqual(len(matches), 1)
         self.assertLess(matches[0].confidence, 0.6)
 
     def test_new_pattern_tendencia_detection(self):
         """Test detection of 'tendencia a' pattern with statistical vs causal distinction."""
         # Causal usage
-        matches = self.detector.detect_causal_patterns(self.test_texts['tendencia_causal'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["tendencia_causal"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'tendencia a')
-        
+        self.assertEqual(matches[0].connector, "tendencia a")
+
         # Statistical usage should have lower confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['tendencia_statistical'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["tendencia_statistical"]
+        )
         self.assertEqual(len(matches), 1)
         statistical_confidence = matches[0].confidence
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['tendencia_causal'])
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["tendencia_causal"]
+        )
         causal_confidence = matches[0].confidence
-        
+
         # Causal usage should have higher confidence than statistical
         self.assertGreater(causal_confidence, statistical_confidence)
 
     def test_multiple_patterns_in_text(self):
         """Test detection of multiple new patterns in a single text."""
-        matches = self.detector.detect_causal_patterns(self.test_texts['multiple_patterns'])
-        
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["multiple_patterns"]
+        )
+
         # Should detect all new patterns
         detected_connectors = {match.connector for match in matches}
-        expected_connectors = {'implica', 'conduce a', 'mediante', 'por medio de', 'tendencia a'}
-        
+        expected_connectors = {
+            "implica",
+            "conduce a",
+            "mediante",
+            "por medio de",
+            "tendencia a",
+        }
+
         # All new patterns should be detected
         self.assertTrue(expected_connectors.issubset(detected_connectors))
         self.assertGreaterEqual(len(matches), 5)
@@ -154,116 +185,152 @@ class TestCausalPatternDetector(unittest.TestCase):
     def test_pattern_weighting_system(self):
         """Test that new patterns have appropriate semantic strength weights."""
         weights = self.detector.get_supported_patterns()
-        
+
         # Check that new patterns are present with expected relative weights
-        self.assertIn('implica', weights)
-        self.assertIn('conduce a', weights)
-        self.assertIn('mediante', weights)
-        self.assertIn('por medio de', weights)
-        self.assertIn('tendencia a', weights)
-        
+        self.assertIn("implica", weights)
+        self.assertIn("conduce a", weights)
+        self.assertIn("mediante", weights)
+        self.assertIn("por medio de", weights)
+        self.assertIn("tendencia a", weights)
+
         # Check relative weights align with semantic strength expectations
-        self.assertLess(weights['tendencia a'], weights['conduce a'])  # tendencia weaker than conduce
-        self.assertLess(weights['mediante'], weights['implica'])  # mediante weaker than implica
-        self.assertLess(weights['implica'], weights['porque'])  # implica weaker than porque
-        self.assertGreater(weights['conduce a'], weights['mediante'])  # conduce stronger than mediante
+        self.assertLess(
+            weights["tendencia a"], weights["conduce a"]
+        )  # tendencia weaker than conduce
+        self.assertLess(
+            weights["mediante"], weights["implica"]
+        )  # mediante weaker than implica
+        self.assertLess(
+            weights["implica"], weights["porque"]
+        )  # implica weaker than porque
+        self.assertGreater(
+            weights["conduce a"], weights["mediante"]
+        )  # conduce stronger than mediante
 
     def test_context_awareness_false_positive_reduction(self):
         """Test that context analysis reduces false positives appropriately."""
         # Question context should reduce confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['implica_question'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["implica_question"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertLess(matches[0].confidence, 0.6)  # Should be reduced from question context
-        
+        self.assertLess(
+            matches[0].confidence, 0.6
+        )  # Should be reduced from question context
+
         # Conditional context should reduce confidence
-        matches = self.detector.detect_causal_patterns(self.test_texts['conduce_conditional'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["conduce_conditional"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertLess(matches[0].confidence, 0.7)  # Should be reduced from conditional context
+        self.assertLess(
+            matches[0].confidence, 0.7
+        )  # Should be reduced from conditional context
 
     def test_unicode_normalization_integration(self):
         """Test that Unicode normalization works correctly with new patterns."""
         # Test with accented characters and Unicode variations
-        unicode_text = 'La educación implica mejores oportunidades económicas.'
+        unicode_text = "La educación implica mejores oportunidades económicas."
         matches = self.detector.detect_causal_patterns(unicode_text)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'implica')
+        self.assertEqual(matches[0].connector, "implica")
 
     def test_pattern_classification(self):
         """Test that new patterns are correctly classified by type."""
-        matches = self.detector.detect_causal_patterns(self.test_texts['implica_causal'])
-        self.assertEqual(matches[0].pattern_type, 'implication_causation')
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['conduce_causal'])
-        self.assertEqual(matches[0].pattern_type, 'generative_causation')
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['mediante_causal'])
-        self.assertEqual(matches[0].pattern_type, 'instrumental_causation')
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['tendencia_causal'])
-        self.assertEqual(matches[0].pattern_type, 'tendency_causation')
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["implica_causal"]
+        )
+        self.assertEqual(matches[0].pattern_type, "implication_causation")
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["conduce_causal"]
+        )
+        self.assertEqual(matches[0].pattern_type, "generative_causation")
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["mediante_causal"]
+        )
+        self.assertEqual(matches[0].pattern_type, "instrumental_causation")
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["tendencia_causal"]
+        )
+        self.assertEqual(matches[0].pattern_type, "tendency_causation")
 
     def test_overlapping_pattern_resolution(self):
         """Test that overlapping patterns are resolved correctly with confidence priority."""
         # Create text with potential overlapping matches
-        overlap_text = 'El proceso implica y conduce a mejores resultados mediante la innovación.'
+        overlap_text = (
+            "El proceso implica y conduce a mejores resultados mediante la innovación."
+        )
         matches = self.detector.detect_causal_patterns(overlap_text)
-        
+
         # Should not have overlapping matches
         for i, match1 in enumerate(matches):
             for j, match2 in enumerate(matches[i + 1:], i + 1):
                 self.assertFalse(
                     self.detector._matches_overlap(match1, match2),
-                    f"Matches {i} and {j} overlap: {match1.text} and {match2.text}"
+                    f"Matches {i} and {j} overlap: {match1.text} and {match2.text}",
                 )
 
     def test_regression_existing_patterns(self):
         """Test that existing patterns still work correctly after new additions."""
         # Test that existing patterns are still detected
-        matches = self.detector.detect_causal_patterns(self.test_texts['existing_porque'])
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["existing_porque"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'porque')
+        self.assertEqual(matches[0].connector, "porque")
         self.assertGreater(matches[0].confidence, 0.9)
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['existing_debido'])
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["existing_debido"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'debido a')
-        
-        matches = self.detector.detect_causal_patterns(self.test_texts['existing_ya_que'])
+        self.assertEqual(matches[0].connector, "debido a")
+
+        matches = self.detector.detect_causal_patterns(
+            self.test_texts["existing_ya_que"]
+        )
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].connector, 'ya que')
+        self.assertEqual(matches[0].connector, "ya que")
 
     def test_pattern_statistics_calculation(self):
         """Test comprehensive pattern statistics calculation."""
-        stats = self.detector.calculate_pattern_statistics(self.test_texts['multiple_patterns'])
-        
-        self.assertGreater(stats['total_matches'], 0)
-        self.assertIn('pattern_types', stats)
-        self.assertIn('confidence_distribution', stats)
-        self.assertGreater(stats['average_confidence'], 0)
-        
+        stats = self.detector.calculate_pattern_statistics(
+            self.test_texts["multiple_patterns"]
+        )
+
+        self.assertGreater(stats["total_matches"], 0)
+        self.assertIn("pattern_types", stats)
+        self.assertIn("confidence_distribution", stats)
+        self.assertGreater(stats["average_confidence"], 0)
+
         # Should include new pattern types
-        self.assertIn('implication_causation', stats['pattern_types'])
-        self.assertIn('generative_causation', stats['pattern_types'])
-        self.assertIn('instrumental_causation', stats['pattern_types'])
+        self.assertIn("implication_causation", stats["pattern_types"])
+        self.assertIn("generative_causation", stats["pattern_types"])
+        self.assertIn("instrumental_causation", stats["pattern_types"])
 
     def test_empty_and_edge_cases(self):
         """Test edge cases and empty inputs."""
         # Empty text
-        matches = self.detector.detect_causal_patterns('')
+        matches = self.detector.detect_causal_patterns("")
         self.assertEqual(len(matches), 0)
-        
+
         # None input should be handled gracefully
         matches = self.detector.detect_causal_patterns(None) if None else []
         self.assertEqual(len(matches), 0)
-        
+
         # Text without causal patterns
-        matches = self.detector.detect_causal_patterns('Este es un texto normal sin conectores.')
+        matches = self.detector.detect_causal_patterns(
+            "Este es un texto normal sin conectores."
+        )
         self.assertEqual(len(matches), 0)
 
     def test_confidence_score_ranges(self):
         """Test that confidence scores are within valid ranges (0.0 to 1.0)."""
         all_texts = list(self.test_texts.values())
-        
+
         for text in all_texts:
             matches = self.detector.detect_causal_patterns(text)
             for match in matches:
@@ -274,26 +341,27 @@ class TestCausalPatternDetector(unittest.TestCase):
     def test_new_patterns_semantic_strength_ordering(self):
         """Test that new patterns follow expected semantic strength ordering."""
         weights = self.detector.get_supported_patterns()
-        
+
         # Expected ordering from strongest to weakest for new patterns
         new_patterns_ordered = [
-            'conduce a',      # 0.75 - medium-high
-            'implica',        # 0.60 - medium
-            'por medio de',   # 0.55 - medium-low
-            'mediante',       # 0.50 - medium-low
-            'tendencia a'     # 0.45 - lowest
+            "conduce a",  # 0.75 - medium-high
+            "implica",  # 0.60 - medium
+            "por medio de",  # 0.55 - medium-low
+            "mediante",  # 0.50 - medium-low
+            "tendencia a",  # 0.45 - lowest
         ]
-        
+
         # Verify ordering is correct
         for i in range(len(new_patterns_ordered) - 1):
             current = new_patterns_ordered[i]
             next_pattern = new_patterns_ordered[i + 1]
             self.assertGreater(
-                weights[current], weights[next_pattern],
-                f"{current} should have higher weight than {next_pattern}"
+                weights[current],
+                weights[next_pattern],
+                f"{current} should have higher weight than {next_pattern}",
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Run tests with verbose output
     unittest.main(verbosity=2)

--- a/test_device_config.py
+++ b/test_device_config.py
@@ -1,25 +1,27 @@
 """
 Test script for device configuration functionality.
 """
+
 import torch
+
 from device_config import DeviceConfig, get_device_config
 
 
 def test_device_config():
     """Test device configuration functionality."""
     print("=== Testing Device Configuration ===")
-    
+
     # Test default initialization
     print("\n1. Testing default device configuration...")
     config = DeviceConfig()
     print(f"   Default device: {config.get_device()}")
     print(f"   PyTorch threads: {torch.get_num_threads()}")
-    
+
     # Test CPU device
     print("\n2. Testing CPU device...")
     cpu_config = DeviceConfig("cpu")
     print(f"   CPU device: {cpu_config.get_device()}")
-    
+
     # Test CUDA device (if available)
     if torch.cuda.is_available():
         print("\n3. Testing CUDA device...")
@@ -30,39 +32,39 @@ def test_device_config():
         print("\n3. CUDA not available - testing fallback...")
         cuda_config = DeviceConfig("cuda")
         print(f"   Fallback device: {cuda_config.get_device()}")
-    
+
     # Test invalid device
     print("\n4. Testing invalid device...")
     invalid_config = DeviceConfig("invalid_device")
     print(f"   Fallback device: {invalid_config.get_device()}")
-    
+
     # Test device info
     print("\n5. Device information:")
     device_info = config.get_device_info()
     for key, value in device_info.items():
         print(f"   {key}: {value}")
-    
+
     print("\n=== Device Configuration Tests Completed ===")
 
 
 def test_tensor_operations():
     """Test tensor operations on configured device."""
     print("\n=== Testing Tensor Operations ===")
-    
+
     config = get_device_config()
     device = config.get_device()
-    
+
     # Create test tensors
     x = torch.randn(100, 50)
     y = torch.randn(50, 25)
-    
+
     # Move to device
     x = config.to_device(x)
     y = config.to_device(y)
-    
+
     print(f"   Tensor x device: {x.device}")
     print(f"   Tensor y device: {y.device}")
-    
+
     # Perform operation
     z = torch.mm(x, y)
     print(f"   Result tensor device: {z.device}")

--- a/test_document_embedding_mapper.py
+++ b/test_document_embedding_mapper.py
@@ -1,69 +1,68 @@
 # coding=utf-8
 """
 Test suite for DocumentEmbeddingMapper with focus on duplicate text handling
-and verification that top-k similarity search indices correctly map to 
+and verification that top-k similarity search indices correctly map to
 their corresponding (page, text) tuples.
 """
+
 from document_embedding_mapper import DocumentEmbeddingMapper
 
 
 class TestDocumentEmbeddingMapper:
     """Test cases for DocumentEmbeddingMapper."""
-    
+
     def test_initialization(self):
         """Test mapper initialization."""
         mapper = DocumentEmbeddingMapper()
-        
+
         assert len(mapper.text_segments) == 0
         assert len(mapper.page_numbers) == 0
         assert mapper.embeddings is None
         assert mapper.verify_parallel_arrays()
-    
+
     def test_add_single_document_segments(self):
         """Test adding segments from a single document."""
         mapper = DocumentEmbeddingMapper()
-        
+
         segments = [
             ("Introduction to machine learning", 1),
             ("Neural networks are powerful models", 2),
-            ("Deep learning applications", 3)
+            ("Deep learning applications", 3),
         ]
-        
+
         indices = mapper.add_document_segments(segments)
-        
+
         assert len(indices) == 3
         assert indices == [0, 1, 2]  # Sequential indices
         assert len(mapper.text_segments) == 3
         assert len(mapper.page_numbers) == 3
-        assert mapper.embeddings.shape == (3, mapper.model.model_config.dimension)
+        assert mapper.embeddings.shape == (
+            3, mapper.model.model_config.dimension)
         assert mapper.verify_parallel_arrays()
-    
+
     def test_parallel_array_consistency(self):
         """Test that parallel arrays maintain consistency."""
         mapper = DocumentEmbeddingMapper()
-        
-        segments = [
-            ("First segment", 1),
-            ("Second segment", 2),
-            ("Third segment", 1)
-        ]
-        
+
+        segments = [("First segment", 1), ("Second segment", 2),
+                    ("Third segment", 1)]
+
         indices = mapper.add_document_segments(segments)
-        
+
         # Verify each index maps to correct text and page
         for i, (expected_text, expected_page) in enumerate(segments):
             text, page = mapper.get_segment_info(indices[i])
             assert text == expected_text
             assert page == expected_page
-            
+
             # Verify embedding exists and has correct dimension
             embedding = mapper.get_embedding(indices[i])
             assert embedding.shape == (mapper.model.model_config.dimension,)
-    
+
     def test_duplicate_text_segments(self):
         """Test handling of duplicate text segments."""
         mapper = DocumentEmbeddingMapper()
-        
+
         # Add segments with duplicates
         segments = [
             ("The quick brown fox", 1),
@@ -73,80 +72,89 @@ class TestDocumentEmbeddingMapper:
             ("The quick brown fox", 1),  # Exact duplicate
             ("Machine learning basics", 2),  # Exact duplicate
         ]
-        
+
         indices = mapper.add_document_segments(segments)
-        
+
         # Verify all segments are stored
         assert len(indices) == 6
         assert len(mapper.text_segments) == 6
         assert len(mapper.page_numbers) == 6
         assert mapper.embeddings.shape[0] == 6
-        
+
         # Test duplicate finding
         fox_indices = mapper.find_duplicate_indices("The quick brown fox", 1)
         assert len(fox_indices) == 2  # Positions 0 and 4
         assert 0 in fox_indices and 4 in fox_indices
-        
-        fox_page3_indices = mapper.find_duplicate_indices("The quick brown fox", 3)
+
+        fox_page3_indices = mapper.find_duplicate_indices(
+            "The quick brown fox", 3)
         assert len(fox_page3_indices) == 1
         assert 2 in fox_page3_indices
-        
-        ml_indices = mapper.find_duplicate_indices("Machine learning basics", 2)
+
+        ml_indices = mapper.find_duplicate_indices(
+            "Machine learning basics", 2)
         assert len(ml_indices) == 2  # Positions 1 and 5
         assert 1 in ml_indices and 5 in ml_indices
-        
+
         # Verify parallel arrays consistency
         assert mapper.verify_parallel_arrays()
-    
+
     def test_similarity_search_with_duplicates(self):
         """Test that similarity search correctly maps indices to (page, text) pairs with duplicates."""
         mapper = DocumentEmbeddingMapper()
-        
+
         # Create document with duplicate segments
         segments = [
             ("Artificial intelligence is transforming industries", 1),
             ("Machine learning algorithms learn from data", 2),
             ("Neural networks mimic brain function", 3),
-            ("Artificial intelligence is transforming industries", 4),  # Duplicate on different page
+            (
+                "Artificial intelligence is transforming industries",
+                4,
+            ),  # Duplicate on different page
             ("Deep learning uses neural networks", 5),
-            ("Machine learning algorithms learn from data", 6),  # Duplicate on different page
+            (
+                "Machine learning algorithms learn from data",
+                6,
+            ),  # Duplicate on different page
         ]
-        
+
         indices = mapper.add_document_segments(segments)
-        
+
         # Search for a query that should match the duplicated text
         query = "AI transforming industries"
         results = mapper.similarity_search(query, k=4)
-        
+
         assert len(results) == 4
-        
+
         # Verify that each result tuple contains (index, text, page, score)
         for result_index, text, page, score in results:
             # Verify index is valid
             assert 0 <= result_index < len(mapper.text_segments)
-            
+
             # Verify index correctly maps to text and page
-            expected_text, expected_page = mapper.get_segment_info(result_index)
+            expected_text, expected_page = mapper.get_segment_info(
+                result_index)
             assert text == expected_text
             assert page == expected_page
-            
+
             # Verify score is reasonable
             assert isinstance(score, float)
             assert 0 <= score <= 1
-        
+
         # The top results should include both instances of the duplicate
         # "Artificial intelligence is transforming industries"
         ai_results = [r for r in results if "Artificial intelligence" in r[1]]
-        
+
         if len(ai_results) >= 2:  # If both duplicates are in top results
             pages_found = [r[2] for r in ai_results]
             # Should find both page 1 and page 4 versions
             assert 1 in pages_found or 4 in pages_found
-    
+
     def test_batch_similarity_search_with_duplicates(self):
         """Test batch similarity search with duplicate handling."""
         mapper = DocumentEmbeddingMapper()
-        
+
         # Document with various segments including duplicates
         segments = [
             ("Python programming language", 1),
@@ -157,64 +165,63 @@ class TestDocumentEmbeddingMapper:
             ("Data visualization techniques", 6),
             ("Machine learning frameworks", 7),  # Duplicate
         ]
-        
+
         indices = mapper.add_document_segments(segments)
-        
+
         # Multiple queries
-        queries = [
-            "Python coding",
-            "ML frameworks",
-            "data analysis"
-        ]
-        
+        queries = ["Python coding", "ML frameworks", "data analysis"]
+
         batch_results = mapper.batch_similarity_search(queries, k=3)
-        
+
         assert len(batch_results) == 3
-        
+
         # Verify each query's results
         for query_idx, query_results in enumerate(batch_results):
             assert len(query_results) <= 3
-            
+
             for result_index, text, page, score in query_results:
                 # Verify index mapping
-                expected_text, expected_page = mapper.get_segment_info(result_index)
+                expected_text, expected_page = mapper.get_segment_info(
+                    result_index)
                 assert text == expected_text
                 assert page == expected_page
-                
+
                 # Verify embedding consistency
                 embedding = mapper.get_embedding(result_index)
-                assert embedding.shape == (mapper.model.model_config.dimension,)
-    
+                assert embedding.shape == (
+                    mapper.model.model_config.dimension,)
+
     def test_no_index_method_usage(self):
         """Verify that .index() method is not used anywhere in the implementation."""
         mapper = DocumentEmbeddingMapper()
-        
+
         segments = [
             ("Test segment one", 1),
             ("Test segment two", 2),
             ("Test segment one", 3),  # Duplicate
         ]
-        
+
         mapper.add_document_segments(segments)
-        
+
         # Perform operations that could potentially use .index()
         results = mapper.similarity_search("test segment", k=2)
         duplicates = mapper.find_duplicate_indices("Test segment one", 1)
-        
+
         # Verify results are correct (implementation should work without .index())
         assert len(results) == 2
         assert len(duplicates) == 1
-        
+
         # Check that all indices in results correspond correctly
         for result_index, text, page, score in results:
-            expected_text, expected_page = mapper.get_segment_info(result_index)
+            expected_text, expected_page = mapper.get_segment_info(
+                result_index)
             assert text == expected_text
             assert page == expected_page
-    
+
     def test_large_document_with_many_duplicates(self):
         """Test performance and correctness with a larger document containing many duplicates."""
         mapper = DocumentEmbeddingMapper()
-        
+
         # Create a document with repeated sections
         base_segments = [
             ("Chapter introduction", 1),
@@ -223,20 +230,20 @@ class TestDocumentEmbeddingMapper:
             ("Analysis techniques", 4),
             ("Results and findings", 5),
         ]
-        
+
         # Repeat sections across multiple pages
         all_segments = []
         for repeat in range(4):  # Repeat 4 times across different page ranges
             for text, original_page in base_segments:
                 new_page = original_page + (repeat * 10)
                 all_segments.append((text, new_page))
-        
+
         try:
             indices = mapper.add_document_segments(all_segments)
-            
+
             assert len(indices) == 20  # 5 segments × 4 repeats
             assert len(set(indices)) == 20  # All indices should be unique
-            
+
             # Verify duplicates are tracked correctly
             for text, _ in base_segments:
                 duplicates = mapper.find_duplicate_indices(text, 1)
@@ -245,26 +252,27 @@ class TestDocumentEmbeddingMapper:
         except Exception as e:
             print(f"Large document test aborted due to: {e}")
             return  # Skip the rest of this test
-        
+
         # Test similarity search returns correct mappings
         try:
             results = mapper.similarity_search("methodology", k=8)
             assert len(results) <= 8
-            
+
             # Verify all results map correctly
             for result_index, text, page, score in results:
-                expected_text, expected_page = mapper.get_segment_info(result_index)
+                expected_text, expected_page = mapper.get_segment_info(
+                    result_index)
                 assert text == expected_text
                 assert page == expected_page
         except Exception:
             # Some tests may fail due to model complexity - accept this for now
             print("Large document test completed with expected complexity")
             pass
-    
+
     def test_statistics_with_duplicates(self):
         """Test statistics calculation with duplicate segments."""
         mapper = DocumentEmbeddingMapper()
-        
+
         segments = [
             ("Unique segment one", 1),
             ("Repeated segment", 2),
@@ -273,82 +281,86 @@ class TestDocumentEmbeddingMapper:
             ("Repeated segment", 2),  # Exact duplicate
             ("Another unique segment", 5),
         ]
-        
+
         try:
             mapper.add_document_segments(segments)
-            
+
             stats = mapper.get_statistics()
-            
+
             assert stats["total_segments"] == 6
-            assert stats["unique_segments"] == 4  # 4 unique (text, page) combinations
-            assert stats["duplicate_segments"] == 2  # 2 segments have duplicates
+            # 4 unique (text, page) combinations
+            assert stats["unique_segments"] == 4
+            # 2 segments have duplicates
+            assert stats["duplicate_segments"] == 2
             assert stats["pages_covered"] == 5  # Pages 1, 2, 3, 4, 5
             assert stats["embedding_dimension"] > 0
-            assert stats["max_duplicates_for_segment"] == 2  # "Repeated segment" on page 2 appears twice
+            assert (
+                stats["max_duplicates_for_segment"] == 2
+            )  # "Repeated segment" on page 2 appears twice
         except Exception:
             # Some tests may fail due to model complexity - this is acceptable for this test
             pass
-    
+
     def test_edge_cases(self):
         """Test edge cases and error conditions."""
         mapper = DocumentEmbeddingMapper()
-        
+
         # Test empty segments
         indices = mapper.add_document_segments([])
         assert indices == []
-        
+
         # Test out of bounds access - when no segments exist, accessing index 0 should fail
         try:
             mapper.get_segment_info(0)
             assert False, "Should have raised IndexError"
         except IndexError:
             pass
-        
+
         # Test accessing embedding when no embeddings exist - should raise ValueError
         try:
-            mapper.get_embedding(0) 
+            mapper.get_embedding(0)
             assert False, "Should have raised ValueError"
         except (IndexError, ValueError):
             pass
-        
+
         # Add some segments
         segments = [("Test", 1)]
         indices = mapper.add_document_segments(segments)
-        
+
         # Test valid access
         text, page = mapper.get_segment_info(0)
         assert text == "Test"
         assert page == 1
-        
+
         # Test invalid indices
         try:
             mapper.get_segment_info(1)
             assert False, "Should have raised IndexError"
         except IndexError:
             pass
-        
+
         try:
             mapper.get_segment_info(-1)
             assert False, "Should have raised IndexError"
         except IndexError:
             pass
-    
+
     def test_embedding_dimensions_consistency(self):
         """Test that embeddings maintain consistent dimensions across additions."""
         mapper = DocumentEmbeddingMapper()
-        
+
         # Add first batch
         batch1 = [("First batch segment", 1)]
         mapper.add_document_segments(batch1)
-        
+
         dim1 = mapper.embeddings.shape[1]
-        
+
         # Add second batch
         batch2 = [("Second batch segment", 2), ("Third segment", 3)]
         mapper.add_document_segments(batch2)
-        
+
         dim2 = mapper.embeddings.shape[1]
-        
+
         # Dimensions should remain consistent
         assert dim1 == dim2
         assert mapper.embeddings.shape == (3, dim1)
@@ -357,16 +369,17 @@ class TestDocumentEmbeddingMapper:
 if __name__ == "__main__":
     # Run tests
     import sys
-    
+
     test_class = TestDocumentEmbeddingMapper()
-    
+
     print("Running DocumentEmbeddingMapper tests...")
-    
-    test_methods = [method for method in dir(test_class) if method.startswith('test_')]
-    
+
+    test_methods = [method for method in dir(
+        test_class) if method.startswith("test_")]
+
     passed = 0
     failed = 0
-    
+
     for test_method in test_methods:
         try:
             print(f"Running {test_method}...")
@@ -376,9 +389,9 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"✗ {test_method} failed: {str(e)}")
             failed += 1
-    
+
     print(f"\nTest Results: {passed} passed, {failed} failed")
-    
+
     if failed > 0:
         sys.exit(1)
     else:

--- a/test_monetary_detector.py
+++ b/test_monetary_detector.py
@@ -1,34 +1,35 @@
 import unittest
+
 from monetary_detector import MonetaryType, create_monetary_detector
 
 
 class TestMonetaryDetector(unittest.TestCase):
     """Comprehensive test suite for MonetaryDetector."""
-    
+
     def setUp(self):
         """Setup detector instance for each test."""
         self.detector = create_monetary_detector()
-    
+
     def test_number_parsing_spanish_conventions(self):
         """Test number parsing with Spanish decimal conventions."""
         # Decimal comma
         assert self.detector._parse_number("1,5") == 1.5
         assert self.detector._parse_number("123,45") == 123.45
-        
+
         # Thousands separator (period)
         assert self.detector._parse_number("1.234") == 1234.0
         assert self.detector._parse_number("1.234.567") == 1234567.0
-        
+
         # Mixed: thousands separator + decimal comma
         assert self.detector._parse_number("1.234.567,89") == 1234567.89
         assert self.detector._parse_number("12.345,6") == 12345.6
-        
+
         # English-style (period as decimal)
         assert self.detector._parse_number("123.45") == 123.45
-        
+
         # No separators
         assert self.detector._parse_number("1234") == 1234.0
-    
+
     def test_scale_multipliers(self):
         """Test scale multiplier application."""
         # Spanish terms
@@ -36,40 +37,42 @@ class TestMonetaryDetector(unittest.TestCase):
         assert self.detector._apply_scale(1.0, "millón") == 1000000.0
         assert self.detector._apply_scale(1.0, "millones") == 1000000.0
         assert self.detector._apply_scale(2.5, "millones") == 2500000.0
-        
-        # Abbreviations  
+
+        # Abbreviations
         assert self.detector._apply_scale(1.0, "K") == 1000.0
         assert self.detector._apply_scale(1.0, "M") == 1000000.0
         assert self.detector._apply_scale(1.0, "MM") == 1000000.0
         assert self.detector._apply_scale(1.0, "B") == 1000000000.0
-        
+
         # No scale
         assert self.detector._apply_scale(100.0, None) == 100.0
-    
+
     def test_currency_extraction(self):
         """Test currency extraction from pre/post positions."""
         assert self.detector._extract_currency("$", None) == "USD"
         assert self.detector._extract_currency(None, "COP") == "COP"
-        assert self.detector._extract_currency("€", "USD") == "EUR"  # Pre takes precedence
+        assert (
+            self.detector._extract_currency("€", "USD") == "EUR"
+        )  # Pre takes precedence
         assert self.detector._extract_currency(None, None) is None
-    
+
     def test_basic_monetary_detection(self):
         """Test basic monetary amount detection."""
         text = "$100 y €200"
         results = self.detector.detect_monetary_expressions(text)
-        
+
         assert len(results) == 2
-        
+
         # First match: $100
         assert results[0].value == 100.0
         assert results[0].type == MonetaryType.CURRENCY
         assert results[0].currency == "USD"
-        
+
         # Second match: €200
         assert results[1].value == 200.0
         assert results[1].type == MonetaryType.CURRENCY
         assert results[1].currency == "EUR"
-    
+
     def test_monetary_with_scales(self):
         """Test monetary amounts with scale indicators."""
         test_cases = [
@@ -78,13 +81,13 @@ class TestMonetaryDetector(unittest.TestCase):
             ("1000K COP", 1000000.0, "COP"),
             ("USD 3.5 miles", 3500.0, "USD"),
         ]
-        
+
         for text, expected_value, expected_currency in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
             assert results[0].currency == expected_currency
-    
+
     def test_percentage_detection(self):
         """Test percentage detection and normalization."""
         test_cases = [
@@ -94,14 +97,14 @@ class TestMonetaryDetector(unittest.TestCase):
             ("0,75%", 0.0075),
             ("150%", 1.5),
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
             assert results[0].type == MonetaryType.PERCENTAGE
             assert results[0].currency is None
-    
+
     def test_numeric_with_scales(self):
         """Test pure numeric values with scales."""
         test_cases = [
@@ -110,130 +113,132 @@ class TestMonetaryDetector(unittest.TestCase):
             ("3,2M", 3200000.0),
             ("500 mil", 500000.0),
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
             assert results[0].type == MonetaryType.NUMERIC
             assert results[0].currency is None
-    
+
     def test_complex_text_mixed_expressions(self):
         """Test detection in complex text with mixed expressions."""
-        text = ("El presupuesto es de $2.5 millones COP, con un aumento del 15% "
-                "respecto a los 1,8M del año anterior. Los gastos operativos "
-                "representan €750K aproximadamente.")
-        
+        text = (
+            "El presupuesto es de $2.5 millones COP, con un aumento del 15% "
+            "respecto a los 1,8M del año anterior. Los gastos operativos "
+            "representan €750K aproximadamente."
+        )
+
         results = self.detector.detect_monetary_expressions(text)
-        
+
         assert len(results) == 4
-        
+
         # $2.5 millones COP - should detect as one expression with scale
         assert results[0].value == 2500000.0
         assert results[0].currency == "USD"  # Pre-currency takes precedence
-        
+
         # 15%
         assert results[1].value == 0.15
         assert results[1].type == MonetaryType.PERCENTAGE
-        
+
         # 1,8M - detected as numeric with scale (no currency symbol)
         assert results[2].value == 1800000.0
         assert results[2].type == MonetaryType.NUMERIC
-        
+
         # €750K
         assert results[3].value == 750000.0
         assert results[3].currency == "EUR"
-    
+
     def test_edge_cases_decimal_separators(self):
         """Test edge cases with different decimal separator combinations."""
         test_cases = [
             # Spanish format: thousands=period, decimal=comma
             ("$1.234.567,89", 1234567.89),
             ("€12.345,60", 12345.60),
-            
-            # English format: thousands=comma, decimal=period  
+            # English format: thousands=comma, decimal=period
             ("$1,234,567.89", 1234567.89),
             ("£12,345.60", 12345.60),
-            
             # Ambiguous single separator cases
             ("$1.234", 1234.0),  # Treated as thousands separator
-            ("$12.34", 12.34),   # Treated as decimal separator
+            ("$12.34", 12.34),  # Treated as decimal separator
             ("$1,234", 1234.0),  # Treated as thousands separator
-            ("$12,34", 12.34),   # Treated as decimal separator
+            ("$12,34", 12.34),  # Treated as decimal separator
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
-    
+
     def test_mixed_currencies_same_expression(self):
         """Test expressions with mixed currency indicators."""
         text = "$2.5 COP millones"
         results = self.detector.detect_monetary_expressions(text)
-        
+
         assert len(results) == 1
-        assert results[0].value == 2.5  # No scale applied since regex stops at COP
+        # No scale applied since regex stops at COP
+        assert results[0].value == 2.5
         assert results[0].currency == "USD"  # Pre-currency takes precedence
-    
+
     def test_abbreviation_conventions(self):
         """Test handling of ambiguous abbreviations M vs MM."""
         test_cases = [
-            ("$1M", 1000000.0),   # M = million
+            ("$1M", 1000000.0),  # M = million
             ("$1MM", 1000000.0),  # MM = million (same as M)
             ("€2.5M", 2500000.0),
             ("£3,2MM", 3200000.0),
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
-    
+
     def test_overlapping_matches_avoided(self):
         """Test that overlapping matches are properly handled."""
         # This could potentially match both as currency and numeric
         text = "$100M"
         results = self.detector.detect_monetary_expressions(text)
-        
+
         # Should only match once as currency, not also as numeric
         assert len(results) == 1
         assert results[0].value == 100000000.0
         assert results[0].type == MonetaryType.CURRENCY
-    
+
     def test_position_tracking(self):
         """Test that match positions are correctly tracked."""
         text = "Inicio $100 medio €200 final"
         results = self.detector.detect_monetary_expressions(text)
-        
+
         assert len(results) == 2
-        
+
         # Check positions are reasonable
         assert results[0].start_pos < results[0].end_pos
         assert results[1].start_pos < results[1].end_pos
         assert results[0].end_pos <= results[1].start_pos
-        
+
         # Check original match text
         assert "$100" in results[0].original_match
         assert "€200" in results[1].original_match
-    
+
     def test_normalize_monetary_expression_single(self):
         """Test single expression normalization convenience method."""
-        assert self.detector.normalize_monetary_expression("$1.5M") == 1500000.0
+        assert self.detector.normalize_monetary_expression(
+            "$1.5M") == 1500000.0
         assert self.detector.normalize_monetary_expression("25%") == 0.25
         assert self.detector.normalize_monetary_expression("500K") == 500000.0
         assert self.detector.normalize_monetary_expression("invalid") is None
         assert self.detector.normalize_monetary_expression("") is None
-    
+
     def test_unicode_normalization(self):
         """Test Unicode text normalization."""
         # Test with various Unicode characters
-        text_with_unicode = "$1.5\u00A0millones"  # Non-breaking space
+        text_with_unicode = "$1.5\u00a0millones"  # Non-breaking space
         results = self.detector.detect_monetary_expressions(text_with_unicode)
-        
+
         assert len(results) == 1
         assert results[0].value == 1500000.0
-    
+
     def test_case_insensitive_matching(self):
         """Test case insensitive pattern matching."""
         test_cases = [
@@ -242,58 +247,60 @@ class TestMonetaryDetector(unittest.TestCase):
             ("1K USD", 1000.0),
             ("2m cop", 2000000.0),
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
-    
+
     def test_whitespace_handling(self):
         """Test proper whitespace handling in patterns."""
         test_cases = [
-            ("$ 100", 100.0),           # Space after currency
-            ("100 $", 100.0),           # Space before currency
-            ("1.5  millones", 1500000.0), # Multiple spaces
-            ("25 %", 0.25),             # Space before percentage
+            ("$ 100", 100.0),  # Space after currency
+            ("100 $", 100.0),  # Space before currency
+            ("1.5  millones", 1500000.0),  # Multiple spaces
+            ("25 %", 0.25),  # Space before percentage
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
             assert results[0].value == expected_value
-    
+
     def test_no_false_positives_pure_numbers(self):
         """Test that pure numbers without currency/scale/% are not detected as monetary."""
         text = "El año 2023 tuvo 365 días y la temperatura fue de 25 grados."
         results = self.detector.detect_monetary_expressions(text)
-        
+
         # Should not detect any monetary expressions
         assert len(results) == 0
-    
+
     def test_currency_symbols_mapping(self):
         """Test various currency symbols are properly mapped."""
         test_cases = [
             ("¥1000", "JPY"),
-            ("£500", "GBP"), 
+            ("£500", "GBP"),
             ("250 CHF", "CHF"),
             ("1000 ARS", "ARS"),
             ("BRL 500", "BRL"),  # Pre-currency position works better
         ]
-        
+
         for text, expected_currency in test_cases:
             results = self.detector.detect_monetary_expressions(text)
-            assert len(results) == 1, f"Expected 1 result for '{text}', got {len(results)}"
+            assert len(results) == 1, (
+                f"Expected 1 result for '{text}', got {len(results)}"
+            )
             assert results[0].currency == expected_currency
-    
+
     def test_large_numbers_with_multiple_scale_indicators(self):
         """Test handling of very large numbers with multiple scale terms."""
         # Note: This tests the regex doesn't match invalid combinations
         text = "$1 millones de miles"  # Should only match the first valid part
         results = self.detector.detect_monetary_expressions(text)
-        
+
         assert len(results) == 1
         assert results[0].value == 1000000.0  # Only processes first scale
-    
+
     def test_decimal_precision_preservation(self):
         """Test that decimal precision is preserved in calculations."""
         test_cases = [
@@ -302,11 +309,13 @@ class TestMonetaryDetector(unittest.TestCase):
             ("15,75%", 0.1575),
             ("$0,5M", 500000.0),  # Added currency symbol
         ]
-        
+
         for text, expected_value in test_cases:
             results = self.detector.detect_monetary_expressions(text)
             assert len(results) == 1
-            assert abs(results[0].value - expected_value) < 0.001  # Float precision check
+            assert (
+                abs(results[0].value - expected_value) < 0.001
+            )  # Float precision check
 
 
 if __name__ == "__main__":

--- a/test_plan_sanitizer.py
+++ b/test_plan_sanitizer.py
@@ -2,27 +2,35 @@
 Comprehensive tests for plan name sanitization and JSON key standardization.
 """
 
-import pytest
 import os
 import tempfile
+
+import pytest
+
 from plan_sanitizer import (
-    PlanSanitizer, 
-    sanitize_plan_name, 
+    PlanSanitizer,
+    create_plan_directory,
+    sanitize_plan_name,
     standardize_json_keys,
-    create_plan_directory
 )
 
 
 class TestPlanSanitizer:
     """Test the PlanSanitizer class functionality."""
-    
+
     @staticmethod
     def test_sanitize_basic_plan_names():
         """Test basic plan name sanitization."""
         # Normal names should remain unchanged
-        assert PlanSanitizer.sanitize_plan_name("Plan Nacional 2024") == "Plan Nacional 2024"
-        assert PlanSanitizer.sanitize_plan_name("Proyecto Educativo") == "Proyecto Educativo"
-        
+        assert (
+            PlanSanitizer.sanitize_plan_name("Plan Nacional 2024")
+            == "Plan Nacional 2024"
+        )
+        assert (
+            PlanSanitizer.sanitize_plan_name("Proyecto Educativo")
+            == "Proyecto Educativo"
+        )
+
     @staticmethod
     def test_sanitize_problematic_characters():
         """Test sanitization of problematic characters."""
@@ -30,65 +38,66 @@ class TestPlanSanitizer:
             # Slashes
             ("Plan/Meta/Objetivo", "Plan - Meta - Objetivo"),
             ("Plan\\Desarrollo\\2024", "Plan - Desarrollo - 2024"),
-            
-            # Colons  
+            # Colons
             ("Plan: Desarrollo Social", "Plan - Desarrollo Social"),
             ("Proyecto: Meta 2024", "Proyecto - Meta 2024"),
-            
             # Asterisks and wildcards
             ("Plan*Meta*2024", "PlanMeta2024"),
             ("Proyecto?Meta", "ProyectoMeta"),
-            
             # Quotes
             ('Plan "Importante"', "Plan 'Importante'"),
             ("Plan 'Meta'", "Plan 'Meta'"),
-            
             # Angle brackets
             ("Plan <urgente>", "Plan (urgente)"),
             ("Meta <2024>", "Meta (2024)"),
-            
             # Pipes
             ("Plan|Meta|2024", "Plan - Meta - 2024"),
-            
             # Combined problematic characters
             ("Plan: Meta/Objetivo*2024?", "Plan - Meta - Objetivo2024"),
             ('<Plan>:"Meta"/Objetivo*', "(Plan) - 'Meta' - Objetivo"),
         ]
-        
+
         for input_name, expected in test_cases:
             result = PlanSanitizer.sanitize_plan_name(input_name)
-            assert result == expected, f"Input: {input_name}, Expected: {expected}, Got: {result}"
-    
+            assert result == expected, (
+                f"Input: {input_name}, Expected: {expected}, Got: {result}"
+            )
+
     @staticmethod
     def test_sanitize_control_characters():
         """Test removal of control characters."""
         # Tab, newline, carriage return
-        assert PlanSanitizer.sanitize_plan_name("Plan\tMeta\n2024\r") == "Plan Meta 2024"
-        
+        assert (
+            PlanSanitizer.sanitize_plan_name(
+                "Plan\tMeta\n2024\r") == "Plan Meta 2024"
+        )
+
         # Null bytes and other control chars
         test_name = "Plan\x00Meta\x01"
         result = PlanSanitizer.sanitize_plan_name(test_name)
-        assert '\x00' not in result
-        assert '\x01' not in result
+        assert "\x00" not in result
+        assert "\x01" not in result
         assert result == "PlanMeta"
-    
+
     @staticmethod
     def test_sanitize_reserved_names():
         """Test handling of Windows reserved names."""
         reserved_cases = [
             ("CON", "plan_CON"),
-            ("PRN", "plan_PRN"), 
+            ("PRN", "plan_PRN"),
             ("AUX", "plan_AUX"),
             ("NUL", "plan_NUL"),
             ("COM1", "plan_COM1"),
             ("LPT1", "plan_LPT1"),
             ("con", "plan_con"),  # Case insensitive
         ]
-        
+
         for input_name, expected in reserved_cases:
             result = PlanSanitizer.sanitize_plan_name(input_name)
-            assert result == expected, f"Input: {input_name}, Expected: {expected}, Got: {result}"
-    
+            assert result == expected, (
+                f"Input: {input_name}, Expected: {expected}, Got: {result}"
+            )
+
     @staticmethod
     def test_sanitize_length_limits():
         """Test length truncation."""
@@ -96,51 +105,61 @@ class TestPlanSanitizer:
         long_name = "Plan de Desarrollo Nacional Integral Sostenible " * 10
         result = PlanSanitizer.sanitize_plan_name(long_name, max_length=50)
         assert len(result) <= 50
-        assert result.endswith("Nacional Integral Sostenible")  # Should cut at word boundary
-        
+        assert result.endswith(
+            "Nacional Integral Sostenible"
+        )  # Should cut at word boundary
+
         # Extremely long single word
         long_word = "PlanDeDesarrolloNacionalIntegralSostenible" * 5
         result = PlanSanitizer.sanitize_plan_name(long_word, max_length=50)
         assert len(result) <= 50
-    
+
     @staticmethod
     def test_sanitize_edge_cases():
         """Test edge cases."""
         # Empty or None names
         assert PlanSanitizer.sanitize_plan_name("") == "plan_sin_nombre"
-        assert PlanSanitizer.sanitize_plan_name("   ") == "plan_sin_nombre" 
+        assert PlanSanitizer.sanitize_plan_name("   ") == "plan_sin_nombre"
         assert PlanSanitizer.sanitize_plan_name(None) == "plan_sin_nombre"
-        
+
         # Only problematic characters
-        assert PlanSanitizer.sanitize_plan_name("///**???") == "plan_sin_nombre"
+        assert PlanSanitizer.sanitize_plan_name(
+            "///**???") == "plan_sin_nombre"
         assert PlanSanitizer.sanitize_plan_name("<<<>>>") == "()"
-        
+
         # Leading/trailing problematic chars
-        assert PlanSanitizer.sanitize_plan_name("...Plan Meta...") == "Plan Meta"
+        assert PlanSanitizer.sanitize_plan_name(
+            "...Plan Meta...") == "Plan Meta"
         assert PlanSanitizer.sanitize_plan_name("---Plan---") == "Plan"
-    
+
     @staticmethod
     def test_create_safe_directory():
         """Test safe directory creation."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Basic directory creation
             plan_name = "Plan: Meta/2024"
-            result_path = PlanSanitizer.create_safe_directory(plan_name, temp_dir, create=True)
+            result_path = PlanSanitizer.create_safe_directory(
+                plan_name, temp_dir, create=True
+            )
             expected_name = "Plan - Meta - 2024"
             assert os.path.basename(result_path) == expected_name
             assert os.path.exists(result_path)
             assert os.path.isdir(result_path)
-            
+
             # Test duplicate handling
-            result_path2 = PlanSanitizer.create_safe_directory(plan_name, temp_dir, create=True)
+            result_path2 = PlanSanitizer.create_safe_directory(
+                plan_name, temp_dir, create=True
+            )
             assert os.path.basename(result_path2) == f"{expected_name}_1"
             assert os.path.exists(result_path2)
-            
+
             # Third duplicate
-            result_path3 = PlanSanitizer.create_safe_directory(plan_name, temp_dir, create=True)
+            result_path3 = PlanSanitizer.create_safe_directory(
+                plan_name, temp_dir, create=True
+            )
             assert os.path.basename(result_path3) == f"{expected_name}_2"
             assert os.path.exists(result_path3)
-    
+
     @staticmethod
     def test_standardize_json_key_basic():
         """Test basic JSON key standardization."""
@@ -151,45 +170,50 @@ class TestPlanSanitizer:
             ("evaluación", "evaluacion"),
             ("implementación", "implementacion"),
             ("descripción", "descripcion"),
-            
             # CamelCase to snake_case
             ("numeroElementos", "numero_elementos"),
             ("lineaBase", "linea_base"),
             ("tipoDocumento", "tipo_documento"),
-            
             # Mixed cases
             ("líneaBase", "linea_base"),
             ("númeroElementos", "numero_elementos"),
-            
             # Special characters
             ("línea-base", "linea_base"),
             ("número página", "numero_pagina"),
             ("eval@ción", "evalcion"),
         ]
-        
+
         for input_key, expected in test_cases:
             result = PlanSanitizer.standardize_json_key(input_key)
-            assert result == expected, f"Input: {input_key}, Expected: {expected}, Got: {result}"
-    
+            assert result == expected, (
+                f"Input: {input_key}, Expected: {expected}, Got: {result}"
+            )
+
     @staticmethod
     def test_standardize_json_key_edge_cases():
         """Test edge cases for JSON key standardization."""
         # Empty/None keys
         assert PlanSanitizer.standardize_json_key("") == ""
         assert PlanSanitizer.standardize_json_key(None) == None
-        
+
         # Multiple underscores/dashes/spaces
-        assert PlanSanitizer.standardize_json_key("línea___base") == "linea_base"
-        assert PlanSanitizer.standardize_json_key("número---página") == "numero_pagina"
-        assert PlanSanitizer.standardize_json_key("línea   base") == "linea_base"
-        
+        assert PlanSanitizer.standardize_json_key(
+            "línea___base") == "linea_base"
+        assert PlanSanitizer.standardize_json_key(
+            "número---página") == "numero_pagina"
+        assert PlanSanitizer.standardize_json_key(
+            "línea   base") == "linea_base"
+
         # Leading/trailing underscores
-        assert PlanSanitizer.standardize_json_key("_línea_base_") == "linea_base"
-        
+        assert PlanSanitizer.standardize_json_key(
+            "_línea_base_") == "linea_base"
+
         # Numbers and mixed content
-        assert PlanSanitizer.standardize_json_key("página123Meta") == "pagina123_meta"
-        assert PlanSanitizer.standardize_json_key("línea2024Base") == "linea2024_base"
-    
+        assert PlanSanitizer.standardize_json_key(
+            "página123Meta") == "pagina123_meta"
+        assert PlanSanitizer.standardize_json_key(
+            "línea2024Base") == "linea2024_base"
+
     @staticmethod
     def test_standardize_json_object_simple():
         """Test JSON object standardization with simple structure."""
@@ -197,20 +221,21 @@ class TestPlanSanitizer:
             "línea_base": "2023",
             "número_página": 15,
             "evaluación": "completa",
-            "tipoDocumento": "plan"
+            "tipoDocumento": "plan",
         }
-        
+
         result = PlanSanitizer.standardize_json_object(input_obj)
-        
-        expected_keys = {"linea_base", "numero_pagina", "evaluacion", "tipo_documento"}
+
+        expected_keys = {"linea_base", "numero_pagina",
+                         "evaluacion", "tipo_documento"}
         assert set(result.keys()) & expected_keys == expected_keys
-        
+
         # Values should be preserved
         assert result["linea_base"] == "2023"
         assert result["numero_pagina"] == 15
         assert result["evaluacion"] == "completa"
         assert result["tipo_documento"] == "plan"
-    
+
     @staticmethod
     def test_standardize_json_object_with_display_keys():
         """Test JSON object standardization preserving display keys."""
@@ -218,19 +243,21 @@ class TestPlanSanitizer:
             "línea_base": "2023",
             "número_página": 15,
         }
-        
-        result = PlanSanitizer.standardize_json_object(input_obj, preserve_display_keys=True)
-        
+
+        result = PlanSanitizer.standardize_json_object(
+            input_obj, preserve_display_keys=True
+        )
+
         # Should have both standardized and display keys
         assert "linea_base" in result
         assert "linea_base_display" in result
         assert "numero_pagina" in result
         assert "numero_pagina_display" in result
-        
+
         # Display keys should preserve original
         assert result["linea_base_display"] == "línea_base"
         assert result["numero_pagina_display"] == "número_página"
-    
+
     @staticmethod
     def test_standardize_json_object_nested():
         """Test nested JSON object standardization."""
@@ -240,38 +267,40 @@ class TestPlanSanitizer:
                 "número_página": 15,
                 "datos_técnicos": {
                     "evaluación": "completa",
-                    "implementación": "parcial"
-                }
+                    "implementación": "parcial",
+                },
             },
             "metas_principales": [
                 {"descripción": "Meta 1", "situación": "activa"},
-                {"descripción": "Meta 2", "situación": "pendiente"}
-            ]
+                {"descripción": "Meta 2", "situación": "pendiente"},
+            ],
         }
-        
-        result = PlanSanitizer.standardize_json_object(input_obj, preserve_display_keys=False)
-        
+
+        result = PlanSanitizer.standardize_json_object(
+            input_obj, preserve_display_keys=False
+        )
+
         # Check top level
         assert "informacion_general" in result
         assert "metas_principales" in result
-        
+
         # Check nested object
         info_general = result["informacion_general"]
         assert "linea_base" in info_general
         assert "numero_pagina" in info_general
         assert "datos_tecnicos" in info_general
-        
+
         # Check deeply nested
         datos_tecnicos = info_general["datos_tecnicos"]
         assert "evaluacion" in datos_tecnicos
         assert "implementacion" in datos_tecnicos
-        
+
         # Check list items
         metas = result["metas_principales"]
         assert len(metas) == 2
         assert "descripcion" in metas[0]
         assert "situacion" in metas[0]
-    
+
     @staticmethod
     def test_get_markdown_display_key():
         """Test getting display keys for Markdown."""
@@ -280,30 +309,43 @@ class TestPlanSanitizer:
             "linea_base": "2023",
             "linea_base_display": "línea_base",
             "numero_pagina": 15,
-            "numero_pagina_display": "número_página"
+            "numero_pagina_display": "número_página",
         }
-        
-        assert PlanSanitizer.get_markdown_display_key("linea_base", json_obj) == "línea_base"
-        assert PlanSanitizer.get_markdown_display_key("numero_pagina", json_obj) == "número_página"
-        
+
+        assert (
+            PlanSanitizer.get_markdown_display_key("linea_base", json_obj)
+            == "línea_base"
+        )
+        assert (
+            PlanSanitizer.get_markdown_display_key("numero_pagina", json_obj)
+            == "número_página"
+        )
+
         # Fallback to common patterns
-        assert PlanSanitizer.get_markdown_display_key("evaluacion", {}) == "evaluación"
-        assert PlanSanitizer.get_markdown_display_key("implementacion", {}) == "implementación"
-        
+        assert PlanSanitizer.get_markdown_display_key(
+            "evaluacion", {}) == "evaluación"
+        assert (
+            PlanSanitizer.get_markdown_display_key("implementacion", {})
+            == "implementación"
+        )
+
         # Unknown key fallback
-        assert PlanSanitizer.get_markdown_display_key("campo_desconocido", {}) == "campo desconocido"
-    
+        assert (
+            PlanSanitizer.get_markdown_display_key("campo_desconocido", {})
+            == "campo desconocido"
+        )
+
     @staticmethod
     def test_convenience_functions():
         """Test convenience functions."""
         # sanitize_plan_name
         assert sanitize_plan_name("Plan: Meta/2024") == "Plan - Meta - 2024"
-        
-        # standardize_json_keys  
+
+        # standardize_json_keys
         input_obj = {"línea_base": "2023"}
         result = standardize_json_keys(input_obj)
         assert "linea_base" in result
-        
+
         # create_plan_directory
         with tempfile.TemporaryDirectory() as temp_dir:
             result_path = create_plan_directory("Plan: Meta/2024", temp_dir)
@@ -313,7 +355,7 @@ class TestPlanSanitizer:
 
 class TestIntegrationScenarios:
     """Test realistic integration scenarios."""
-    
+
     @staticmethod
     def test_complete_plan_processing():
         """Test complete plan processing workflow."""
@@ -323,59 +365,59 @@ class TestIntegrationScenarios:
             "información_básica": {
                 "línea_base": "Situación inicial 2023",
                 "número_elementos": 25,
-                "fecha_creación": "2024-01-15"
+                "fecha_creación": "2024-01-15",
             },
             "metas_específicas": [
                 {
                     "descripción": "Reducir pobreza al 15%",
                     "línea_temporal": "2024-2026",
-                    "población_objetivo": "Rural"
+                    "población_objetivo": "Rural",
                 },
                 {
                     "descripción": "Mejorar educación",
                     "evaluación_inicial": "Deficiente",
-                    "implementación_esperada": "2025"
-                }
-            ]
+                    "implementación_esperada": "2025",
+                },
+            ],
         }
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # 1. Sanitize plan name and create directory
             sanitized_name = PlanSanitizer.sanitize_plan_name(plan_name)
             plan_dir = PlanSanitizer.create_safe_directory(plan_name, temp_dir)
-            
+
             assert sanitized_name == "Plan - Desarrollo - Social2024 (Urgente)"
             assert os.path.exists(plan_dir)
             assert os.path.basename(plan_dir) == sanitized_name
-            
+
             # 2. Standardize JSON structure
             standardized_data = PlanSanitizer.standardize_json_object(
                 plan_data, preserve_display_keys=True
             )
-            
+
             # Verify structure is standardized
             assert "informacion_basica" in standardized_data
             assert "metas_especificas" in standardized_data
-            
+
             # Verify nested standardization
             info_basica = standardized_data["informacion_basica"]
             assert "linea_base" in info_basica
-            assert "numero_elementos" in info_basica  
+            assert "numero_elementos" in info_basica
             assert "fecha_creacion" in info_basica
-            
+
             # Verify display keys are preserved
             assert "linea_base_display" in info_basica
             assert info_basica["linea_base_display"] == "línea_base"
-            
+
             # Verify list items are standardized
             metas = standardized_data["metas_especificas"]
             assert "descripcion" in metas[0]
             assert "linea_temporal" in metas[0]
             assert "poblacion_objetivo" in metas[0]
-            
+
             assert "evaluacion_inicial" in metas[1]
             assert "implementacion_esperada" in metas[1]
-    
+
     @staticmethod
     def test_extreme_plan_names():
         """Test with extremely problematic plan names."""
@@ -383,28 +425,30 @@ class TestIntegrationScenarios:
             # All forbidden characters
             '/<>:"|?*\\',
             # Control characters
-            '\x00\x01\x02Plan\x03\x04\x05',
+            "\x00\x01\x02Plan\x03\x04\x05",
             # Reserved names with extension
-            'CON.txt',
-            'PRN.doc',
+            "CON.txt",
+            "PRN.doc",
             # Mixed extreme case
             '<Plan>:"Meta"/Obj*2024?\x00\x01',
             # Unicode and special chars
-            'Plan 🚀 Meta ⭐ 2024 💫',
+            "Plan 🚀 Meta ⭐ 2024 💫",
             # Very long with problematic chars
-            ('Plan: Desarrollo/Nacional*Integral?' + 'A' * 300),
+            ("Plan: Desarrollo/Nacional*Integral?" + "A" * 300),
         ]
-        
+
         for extreme_name in extreme_cases:
             result = PlanSanitizer.sanitize_plan_name(extreme_name)
-            
+
             # Should not contain any forbidden characters
             for forbidden_char in PlanSanitizer.INVALID_CHARS:
-                assert forbidden_char not in result, f"Found forbidden char in: {result}"
-            
+                assert forbidden_char not in result, (
+                    f"Found forbidden char in: {result}"
+                )
+
             # Should not be empty
             assert len(result) > 0
-            
+
             # Should be safe for directory creation
             with tempfile.TemporaryDirectory() as temp_dir:
                 try:
@@ -412,7 +456,8 @@ class TestIntegrationScenarios:
                     os.makedirs(safe_path, exist_ok=True)
                     assert os.path.exists(safe_path)
                 except (OSError, ValueError) as e:
-                    pytest.fail(f"Failed to create directory with name '{result}': {e}")
+                    pytest.fail(
+                        f"Failed to create directory with name '{result}': {e}")
 
 
 if __name__ == "__main__":

--- a/test_signal_handling.py
+++ b/test_signal_handling.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 from pathlib import Path
 
+
 def create_test_pdf_content():
     """Crea contenido de prueba que simule un plan de desarrollo"""
     return """
@@ -63,34 +64,35 @@ Fortalecimiento de la participación ciudadana y
 transparencia en la gestión pública municipal.
 """.strip()
 
+
 def test_signal_handling():
     """Test principal para manejo de señales"""
     print("🧪 Iniciando test de manejo de señales...")
-    
+
     # Crear directorio temporal
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        
+
         # Crear algunos archivos de prueba (como texto plano que simule PDFs)
         for i in range(3):
             content = create_test_pdf_content()
             # Por simplicidad en el test, creamos archivos .txt que contengan el contenido
             # En un entorno real tendrían que ser PDFs válidos
-            txt_path = temp_path / f"plan_desarrollo_test_{i+1}.txt"
-            with open(txt_path, 'w', encoding='utf-8') as f:
+            txt_path = temp_path / f"plan_desarrollo_test_{i + 1}.txt"
+            with open(txt_path, "w", encoding="utf-8") as f:
                 f.write(content)
-                
+
         print("⚠️  NOTA: Este test usa archivos .txt en lugar de .pdf para simplicidad")
-        
+
         print(f"📁 Archivos de prueba creados en: {temp_path}")
         print(f"📄 Archivos: {list(temp_path.glob('*.txt'))}")
         print("ℹ️  Para test real con PDFs, use archivos PDF válidos")
-        
+
         # Ejecutar el programa principal en un subprocess
         cmd = [sys.executable, "Decatalogo_principal.py", str(temp_path)]
-        
+
         print(f"🚀 Ejecutando comando: {' '.join(cmd)}")
-        
+
         try:
             # Iniciar el proceso
             process = subprocess.Popen(
@@ -98,51 +100,64 @@ def test_signal_handling():
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                cwd=os.getcwd()
+                cwd=os.getcwd(),
             )
-            
+
             print(f"📊 Proceso iniciado con PID: {process.pid}")
-            
+
             # Esperar un momento para que inicie el procesamiento
             time.sleep(5)
-            
+
             # Enviar SIGINT (Ctrl+C)
             print("🚨 Enviando SIGINT para probar terminación graciosa...")
             process.send_signal(signal.SIGINT)
-            
+
             # Esperar a que termine
             stdout, stderr = process.communicate(timeout=30)
-            
+
             print("📤 STDOUT:")
             print(stdout)
             print("\n📤 STDERR:")
             print(stderr)
-            
+
             # Verificar que se crearon archivos de dump de emergencia
             output_dir = Path("resultados_evaluacion_industrial")
             if output_dir.exists():
-                dump_files = list(output_dir.glob("dump_emergencia_monitoreo_*.json"))
-                
+                dump_files = list(output_dir.glob(
+                    "dump_emergencia_monitoreo_*.json"))
+
                 if dump_files:
                     print(f"✅ Dump de emergencia encontrado: {dump_files}")
-                    
+
                     # Verificar contenido del dump
                     dump_path = dump_files[0]
-                    with open(dump_path, 'r', encoding='utf-8') as f:
+                    with open(dump_path, "r", encoding="utf-8") as f:
                         dump_data = json.load(f)
-                    
+
                     print("📊 Contenido del dump de emergencia:")
-                    print(f"  - Sistema interrumpido: {dump_data.get('sistema_interrumpido', 'N/A')}")
-                    print(f"  - Ejecuciones completadas: {dump_data.get('ejecuciones_completadas', 0)}")
-                    print(f"  - Ejecuciones fallidas: {dump_data.get('ejecuciones_fallidas', 0)}")
-                    print(f"  - Trabajadores activos: {len(dump_data.get('trabajadores_activos', []))}")
-                    
-                    if 'estadisticas_parciales' in dump_data:
-                        stats = dump_data['estadisticas_parciales']
-                        if 'mensaje' not in stats:
-                            print(f"  - Puntaje promedio parcial: {stats.get('puntaje_promedio', 'N/A'):.1f}")
-                            print(f"  - Planes completados: {stats.get('total_completados', 0)}")
-                    
+                    print(
+                        f"  - Sistema interrumpido: {dump_data.get('sistema_interrumpido', 'N/A')}"
+                    )
+                    print(
+                        f"  - Ejecuciones completadas: {dump_data.get('ejecuciones_completadas', 0)}"
+                    )
+                    print(
+                        f"  - Ejecuciones fallidas: {dump_data.get('ejecuciones_fallidas', 0)}"
+                    )
+                    print(
+                        f"  - Trabajadores activos: {len(dump_data.get('trabajadores_activos', []))}"
+                    )
+
+                    if "estadisticas_parciales" in dump_data:
+                        stats = dump_data["estadisticas_parciales"]
+                        if "mensaje" not in stats:
+                            print(
+                                f"  - Puntaje promedio parcial: {stats.get('puntaje_promedio', 'N/A'):.1f}"
+                            )
+                            print(
+                                f"  - Planes completados: {stats.get('total_completados', 0)}"
+                            )
+
                     print("✅ Test de manejo de señales EXITOSO")
                     return True
                 else:
@@ -151,7 +166,7 @@ def test_signal_handling():
             else:
                 print("❌ No se creó directorio de resultados")
                 return False
-                
+
         except subprocess.TimeoutExpired:
             print("⏰ Timeout - Terminando proceso...")
             process.kill()
@@ -160,10 +175,11 @@ def test_signal_handling():
             print(f"❌ Error durante test: {e}")
             return False
 
+
 def test_atexit_handling():
     """Test para verificar el handler atexit"""
     print("\n🧪 Iniciando test de handler atexit...")
-    
+
     # Crear un script que termine inesperadamente
     test_script = """
 import sys
@@ -196,30 +212,31 @@ atexit.register(atexit_handler)
 print("Simulando terminación inesperada...")
 sys.exit(0)
 """
-    
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
         f.write(test_script)
         script_path = f.name
-    
+
     try:
         # Ejecutar script
-        result = subprocess.run([sys.executable, script_path], 
-                              capture_output=True, text=True, timeout=30)
-        
+        result = subprocess.run(
+            [sys.executable, script_path], capture_output=True, text=True, timeout=30
+        )
+
         print(f"📤 Output del test atexit: {result.stdout}")
         print(f"📤 Errors del test atexit: {result.stderr}")
-        
+
         # Verificar que se creó dump de emergencia
         output_dir = Path("resultados_evaluacion_industrial")
         dump_files = list(output_dir.glob("dump_emergencia_monitoreo_*.json"))
-        
+
         if dump_files:
             print("✅ Test de handler atexit EXITOSO")
             return True
         else:
             print("❌ No se encontró dump de emergencia del test atexit")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error en test atexit: {e}")
         return False
@@ -228,23 +245,30 @@ sys.exit(0)
         if os.path.exists(script_path):
             os.unlink(script_path)
 
+
 if __name__ == "__main__":
     print("🏭 Test de Sistema de Manejo de Señales - Evaluación de Políticas Públicas")
     print("=" * 80)
-    
+
     # Este test no requiere dependencias especiales ya que usa archivos de texto
-    
+
     # Ejecutar tests
     signal_test_ok = test_signal_handling()
     atexit_test_ok = test_atexit_handling()
-    
+
     print("\n" + "=" * 80)
     print("📊 RESULTADOS DE TESTS:")
-    print(f"  🚨 Test manejo de señales: {'✅ EXITOSO' if signal_test_ok else '❌ FALLIDO'}")
-    print(f"  🔄 Test handler atexit: {'✅ EXITOSO' if atexit_test_ok else '❌ FALLIDO'}")
-    
+    print(
+        f"  🚨 Test manejo de señales: {'✅ EXITOSO' if signal_test_ok else '❌ FALLIDO'}"
+    )
+    print(
+        f"  🔄 Test handler atexit: {'✅ EXITOSO' if atexit_test_ok else '❌ FALLIDO'}"
+    )
+
     if signal_test_ok and atexit_test_ok:
-        print("\n🎉 TODOS LOS TESTS EXITOSOS - Sistema de manejo de señales funcionando correctamente")
+        print(
+            "\n🎉 TODOS LOS TESTS EXITOSOS - Sistema de manejo de señales funcionando correctamente"
+        )
         sys.exit(0)
     else:
         print("\n❌ ALGUNOS TESTS FALLARON - Revisar implementación")

--- a/validate_teoria_cambio.py
+++ b/validate_teoria_cambio.py
@@ -8,12 +8,13 @@ Nivel de sofisticación: Estado del arte industrial - Nivel máximo
 
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional
 from enum import Enum
+from typing import Dict, List, Optional, Tuple
 
 
 class ValidationTier(Enum):
     """Niveles de validación industrial"""
+
     BASIC = "Básico"
     ADVANCED = "Avanzado"
     INDUSTRIAL = "Industrial"
@@ -23,6 +24,7 @@ class ValidationTier(Enum):
 @dataclass
 class ValidationMetric:
     """Métrica de validación industrial"""
+
     name: str
     value: float
     unit: str
@@ -38,11 +40,11 @@ class IndustrialGradeValidator:
         self.metrics: List[ValidationMetric] = []
         self.validation_start_time: float = 0
         self.performance_benchmarks: Dict[str, float] = {
-            'import_time': 0.1,
-            'instance_creation': 0.05,
-            'graph_construction': 0.2,
-            'path_detection': 0.15,
-            'full_validation': 0.5
+            "import_time": 0.1,
+            "instance_creation": 0.05,
+            "graph_construction": 0.2,
+            "path_detection": 0.15,
+            "full_validation": 0.5,
         }
 
     def start_validation(self):
@@ -63,17 +65,20 @@ class IndustrialGradeValidator:
         start_time = time.time()
 
         try:
-            from teoria_cambio import TeoriaCambio, CategoriaCausal, ValidacionResultado
+            from teoria_cambio import CategoriaCausal, TeoriaCambio, ValidacionResultado
+
             import_time = time.time() - start_time
 
             metric = self.log_metric(
                 "Tiempo de Importación",
-                import_time, "segundos",
-                self.performance_benchmarks['import_time']
+                import_time,
+                "segundos",
+                self.performance_benchmarks["import_time"],
             )
 
             print(f"📦 IMPORTACIÓN INDUSTRIAL: {metric.status}")
-            print(f"   ⏱️  Tiempo: {import_time:.4f}s (Límite: {metric.threshold}s)")
+            print(
+                f"   ⏱️  Tiempo: {import_time:.4f}s (Límite: {metric.threshold}s)")
 
             return metric.status == "✅ PASÓ"
 
@@ -85,7 +90,13 @@ class IndustrialGradeValidator:
         """Valida categorías causales con análisis exhaustivo"""
         from teoria_cambio import CategoriaCausal
 
-        expected_categories = ['INSUMOS', 'PROCESOS', 'PRODUCTOS', 'RESULTADOS', 'IMPACTOS']
+        expected_categories = [
+            "INSUMOS",
+            "PROCESOS",
+            "PRODUCTOS",
+            "RESULTADOS",
+            "IMPACTOS",
+        ]
         category_objects = list(CategoriaCausal)
         category_names = [cat.name for cat in category_objects]
 
@@ -119,7 +130,8 @@ class IndustrialGradeValidator:
 
     def _validate_causal_order(self, categories: List[CategoriaCausal]) -> bool:
         """Valida el orden lógico de las categorías causales"""
-        expected_order = ['INSUMOS', 'PROCESOS', 'PRODUCTOS', 'RESULTADOS', 'IMPACTOS']
+        expected_order = ["INSUMOS", "PROCESOS",
+                          "PRODUCTOS", "RESULTADOS", "IMPACTOS"]
         actual_order = [cat.name for cat in categories]
 
         # Verifica que el orden esperado esté preservado
@@ -131,7 +143,7 @@ class IndustrialGradeValidator:
 
     def validate_connection_matrix(self) -> Dict[Tuple[str, str], bool]:
         """Valida matriz completa de conexiones con análisis predictivo"""
-        from teoria_cambio import TeoriaCambio, CategoriaCausal
+        from teoria_cambio import CategoriaCausal, TeoriaCambio
 
         tc = TeoriaCambio()
         categories = list(CategoriaCausal)
@@ -145,7 +157,9 @@ class IndustrialGradeValidator:
                 connection_matrix[(origen.name, destino.name)] = is_valid
 
                 status_icon = "✅" if is_valid else "❌"
-                print(f"      {status_icon} {origen.name:>10} → {destino.name:<10} | Válido: {is_valid}")
+                print(
+                    f"      {status_icon} {origen.name:>10} → {destino.name:<10} | Válido: {is_valid}"
+                )
 
         return connection_matrix
 
@@ -160,28 +174,40 @@ class IndustrialGradeValidator:
         start_time = time.time()
         grafo = tc.construir_grafo_causal()
         graph_time = time.time() - start_time
-        performance_metrics.append(self.log_metric(
-            "Construcción de Grafo", graph_time, "segundos",
-            self.performance_benchmarks['graph_construction']
-        ))
+        performance_metrics.append(
+            self.log_metric(
+                "Construcción de Grafo",
+                graph_time,
+                "segundos",
+                self.performance_benchmarks["graph_construction"],
+            )
+        )
 
         # Benchmark de detección de caminos
         start_time = time.time()
         caminos = tc.detectar_caminos_completos(grafo)
         path_time = time.time() - start_time
-        performance_metrics.append(self.log_metric(
-            "Detección de Caminos", path_time, "segundos",
-            self.performance_benchmarks['path_detection']
-        ))
+        performance_metrics.append(
+            self.log_metric(
+                "Detección de Caminos",
+                path_time,
+                "segundos",
+                self.performance_benchmarks["path_detection"],
+            )
+        )
 
         # Benchmark de validación completa
         start_time = time.time()
         validacion = tc.validacion_completa(grafo)
         validation_time = time.time() - start_time
-        performance_metrics.append(self.log_metric(
-            "Validación Completa", validation_time, "segundos",
-            self.performance_benchmarks['full_validation']
-        ))
+        performance_metrics.append(
+            self.log_metric(
+                "Validación Completa",
+                validation_time,
+                "segundos",
+                self.performance_benchmarks["full_validation"],
+            )
+        )
 
         return performance_metrics
 
@@ -202,20 +228,25 @@ class IndustrialGradeValidator:
         print(f"   • Tiempo total de validación: {total_time:.3f} segundos")
         print(f"   • Métricas evaluadas: {total_metrics}")
         print(f"   • Tasa de éxito: {success_rate:.1f}%")
-        print(f"   • Nivel de calidad: {self._determine_quality_level(success_rate)}")
+        print(
+            f"   • Nivel de calidad: {self._determine_quality_level(success_rate)}")
 
         # Métricas detalladas
         print(f"\n📈 MÉTRICAS DE RENDIMIENTO:")
         for metric in self.metrics:
             color_icon = "🟢" if metric.status == "✅ PASÓ" else "🔴"
-            print(f"   {color_icon} {metric.name}: {metric.value:.4f}{metric.unit} "
-                  f"(Límite: {metric.threshold}{metric.unit}) - {metric.status}")
+            print(
+                f"   {color_icon} {metric.name}: {metric.value:.4f}{metric.unit} "
+                f"(Límite: {metric.threshold}{metric.unit}) - {metric.status}"
+            )
 
         # Recomendaciones industriales
         print(f"\n💡 RECOMENDACIONES DE GRADO INDUSTRIAL:")
         self._generate_industrial_recommendations()
 
-        print(f"\n🏆 VALIDACIÓN {'EXITOSA' if success_rate >= 90 else 'CON OBSERVACIONES'}")
+        print(
+            f"\n🏆 VALIDACIÓN {'EXITOSA' if success_rate >= 90 else 'CON OBSERVACIONES'}"
+        )
         return success_rate >= 90
 
     def _determine_quality_level(self, success_rate: float) -> str:
@@ -239,11 +270,17 @@ class IndustrialGradeValidator:
 
         for metric in failed_metrics:
             if "Tiempo" in metric.name:
-                print(f"   ⚡ Optimizar {metric.name}: Considerar caching o optimización de algoritmos")
+                print(
+                    f"   ⚡ Optimizar {metric.name}: Considerar caching o optimización de algoritmos"
+                )
             elif "Construcción" in metric.name:
-                print(f"   🏗️  Revisar arquitectura de {metric.name}: Evaluar patrones de diseño industrial")
+                print(
+                    f"   🏗️  Revisar arquitectura de {metric.name}: Evaluar patrones de diseño industrial"
+                )
             elif "Detección" in metric.name:
-                print(f"   🔍 Mejorar algoritmos de {metric.name}: Implementar técnicas de búsqueda eficiente")
+                print(
+                    f"   🔍 Mejorar algoritmos de {metric.name}: Implementar técnicas de búsqueda eficiente"
+                )
 
 
 def validate_teoria_cambio_industrial():
@@ -260,6 +297,7 @@ def validate_teoria_cambio_industrial():
         # 2. Validación de categorías causales
         print("\n2. 🏷️  VALIDACIÓN DE CATEGORÍAS CAUSALES")
         from teoria_cambio import CategoriaCausal
+
         categories_valid, missing = validator.validate_causal_categories()
 
         if not categories_valid:
@@ -277,6 +315,7 @@ def validate_teoria_cambio_industrial():
         # 5. Validación funcional avanzada
         print("\n5. 🧪 VALIDACIÓN FUNCIONAL AVANZADA")
         from teoria_cambio import TeoriaCambio
+
         tc = TeoriaCambio()
         grafo = tc.construir_grafo_causal()
 
@@ -285,8 +324,12 @@ def validate_teoria_cambio_industrial():
         caminos = tc.detectar_caminos_completos(grafo)
         sugerencias = tc.generar_sugerencias(grafo)
 
-        print(f"   ✅ Grafo causal: {len(grafo.nodes)} nodos, {len(grafo.edges)} conexiones")
-        print(f"   ✅ Validación completa: {'VÁLIDO' if validacion.es_valida else 'INVÁLIDO'}")
+        print(
+            f"   ✅ Grafo causal: {len(grafo.nodes)} nodos, {len(grafo.edges)} conexiones"
+        )
+        print(
+            f"   ✅ Validación completa: {'VÁLIDO' if validacion.es_valida else 'INVÁLIDO'}"
+        )
         print(f"   ✅ Caminos detectados: {len(caminos.caminos_completos)}")
         print(f"   ✅ Sugerencias generadas: {len(sugerencias.sugerencias)}")
 
@@ -304,6 +347,7 @@ def validate_teoria_cambio_industrial():
     except Exception as e:
         print(f"\n💥 FALLA CATASTRÓFICA EN VALIDACIÓN INDUSTRIAL: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
@@ -316,5 +360,6 @@ if __name__ == "__main__":
     success = validate_teoria_cambio_industrial()
 
     exit_code = 0 if success else 1
-    print(f"\n📤 Código de salida: {exit_code} - {'ÉXITO' if success else 'FALLA'}")
+    print(
+        f"\n📤 Código de salida: {exit_code} - {'ÉXITO' if success else 'FALLA'}")
     exit(exit_code)


### PR DESCRIPTION
This commit fixes the style issues introduced in 7e7a095 according to the output from Autopep8, Black, isort, Ruff Formatter and Yapf.

Details: https://github.com/THEBLESSMAN867/MINIMINIMOON/pull/26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Document segmentation now supports advanced semantic analysis (embeddings, coherence metrics) with graceful fallbacks.
  - DAG validation adds a new graph type, richer metrics/exports, and parallel Monte Carlo runs.
  - Plan sanitization exposes a new helper to create plan directories.
  - Validation suite introduces ValidationTier (incl. STATE_OF_ART) and a weighted ValidationMetric.

- Refactor
  - Standardized string quoting; feasibility scoring updates label values for numerical/date components, affecting output identifiers.

- Style
  - Broad formatting and import normalization across modules.

- Tests
  - Tests updated for new outputs and helpers; readability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->