### PR TITLE
Relax dependency guard for SotaEmbedding and add coverage

### DIFF
--- a/embedding_model.py
+++ b/embedding_model.py
@@ -91,24 +91,17 @@ CALIBRACIONES IMPLEMENTADAS:
 class EmbeddingConfig(BaseModel):
     """Configuración para el backend de embeddings."""
 
-    model: str = Field(default="BAAI/bge-m3",
-                       description="Modelo SOTA para embeddings")
-    precision: str = Field(
-        default="fp16", description="Precisión: fp16, fp32, int8")
-    batch_size: int = Field(
-        default=64, description="Tamaño de lote para encoding")
-    normalize_l2: bool = Field(
-        default=True, description="Normalización L2 automática")
-    similarity: str = Field(
-        default="cosine", description="Métrica: cosine, dot")
+    model: str = Field(default="BAAI/bge-m3", description="Modelo SOTA para embeddings")
+    precision: str = Field(default="fp16", description="Precisión: fp16, fp32, int8")
+    batch_size: int = Field(default=64, description="Tamaño de lote para encoding")
+    normalize_l2: bool = Field(default=True, description="Normalización L2 automática")
+    similarity: str = Field(default="cosine", description="Métrica: cosine, dot")
     calibration_card: str = Field(
         default="data/calibration/embedding_pdm.card.json",
         description="Ruta calibración",
     )
-    domain_hint_default: str = Field(
-        default="PDM", description="Dominio por defecto")
-    device: str = Field(
-        default="auto", description="Dispositivo: auto, cuda, cpu")
+    domain_hint_default: str = Field(default="PDM", description="Dominio por defecto")
+    device: str = Field(default="auto", description="Dispositivo: auto, cuda, cpu")
 
 
 class CalibrationCorpusStats(BaseModel):
@@ -207,11 +200,8 @@ class NoveltyGuard:
                 error_msg += f"Faltantes: {', '.join(missing_required)}\n"
             if outdated_required:
                 error_msg += f"Desactualizadas: {', '.join(outdated_required)}\n"
-            error_msg += (
-                "Ejecute: pip install --upgrade "
-                + " ".join(sorted(
-                    pkg for pkg, cfg in dependency_matrix.items() if cfg["required"]
-                ))
+            error_msg += "Ejecute: pip install --upgrade " + " ".join(
+                sorted(pkg for pkg, cfg in dependency_matrix.items() if cfg["required"])
             )
             raise ImportError(error_msg)
 
@@ -297,8 +287,7 @@ class SotaEmbedding:
         logger.info(f"Cargando modelo {self.config.model} en {self._device}")
 
         try:
-            self.model = SentenceTransformer(
-                self.config.model, device=self._device)
+            self.model = SentenceTransformer(self.config.model, device=self._device)
 
             # Configurar precisión
             if self.config.precision == "fp16" and self._device.type == "cuda":
@@ -332,8 +321,7 @@ class SotaEmbedding:
                 self.calibration_card = CalibrationCard(**card_data)
                 logger.info(f"✓ Tarjeta de calibración cargada: {card_path}")
             except Exception as e:
-                logger.warning(
-                    f"No se pudo cargar tarjeta de calibración: {e}")
+                logger.warning(f"No se pudo cargar tarjeta de calibración: {e}")
                 self._create_default_calibration_card()
         else:
             self._create_default_calibration_card()
@@ -434,8 +422,7 @@ class SotaEmbedding:
 
             # Aplicar suavizado de dominio si se especifica
             if domain_hint:
-                embeddings = self._apply_domain_smoothing(
-                    embeddings, domain_hint)
+                embeddings = self._apply_domain_smoothing(embeddings, domain_hint)
 
             # Cachear resultados
             self._cache[cache_key] = embeddings
@@ -489,8 +476,7 @@ class SotaEmbedding:
         )
 
         # 3. Actualizar priors de dominio
-        domain_priors = self._compute_domain_priors(
-            corpus_stats.domain_distribution)
+        domain_priors = self._compute_domain_priors(corpus_stats.domain_distribution)
 
         # 4. Crear tarjeta de calibración
         self.calibration_card = CalibrationCard(
@@ -557,8 +543,7 @@ class SotaEmbedding:
             return {"PDM": 0.9, "general": 0.1}
 
         # Suavizado additivo para evitar ceros
-        total = sum(domain_distribution.values()) + \
-            len(domain_distribution) * 0.1
+        total = sum(domain_distribution.values()) + len(domain_distribution) * 0.1
         priors = {}
         for domain, count in domain_distribution.items():
             priors[domain] = (count + 0.1) / total
@@ -575,8 +560,7 @@ class SotaEmbedding:
         card_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(card_path, "w", encoding="utf-8") as f:
-            json.dump(self.calibration_card.dict(),
-                      f, indent=2, ensure_ascii=False)
+            json.dump(self.calibration_card.dict(), f, indent=2, ensure_ascii=False)
 
         logger.info(f"✓ Tarjeta de calibración guardada: {card_path}")
 
@@ -649,13 +633,11 @@ app = typer.Typer(name="pdm-embed", help="CLI para gestión de embeddings PDM")
 
 @app.command()
 def build_card(
-    corpus_path: str = typer.Argument(...,
-                                      help="Ruta al corpus de calibración"),
+    corpus_path: str = typer.Argument(..., help="Ruta al corpus de calibración"),
     alpha: float = typer.Option(
         0.10, help="Nivel de significancia para conformal prediction"
     ),
-    output: str = typer.Option(
-        None, help="Ruta de salida para tarjeta de calibración"),
+    output: str = typer.Option(None, help="Ruta de salida para tarjeta de calibración"),
 ):
     """Construye tarjeta de calibración desde corpus."""
     try:
@@ -672,8 +654,7 @@ def build_card(
         embedding_backend.save_card(output_path)
 
         typer.echo(f"✓ Tarjeta de calibración generada: {output_path}")
-        typer.echo(
-            f"  Umbrales conformales: {calibration_card.conformal_thresholds}")
+        typer.echo(f"  Umbrales conformales: {calibration_card.conformal_thresholds}")
 
     except Exception as e:
         typer.echo(f"❌ Error construyendo tarjeta: {e}", err=True)
@@ -682,10 +663,8 @@ def build_card(
 
 @app.command()
 def encode(
-    input_file: str = typer.Argument(...,
-                                     help="Archivo de texto con documentos"),
-    output_file: str = typer.Argument(...,
-                                      help="Archivo de salida para embeddings"),
+    input_file: str = typer.Argument(..., help="Archivo de texto con documentos"),
+    output_file: str = typer.Argument(..., help="Archivo de salida para embeddings"),
     batch_size: int = typer.Option(64, help="Tamaño de lote para encoding"),
     domain: str = typer.Option("PDM", help="Dominio para suavizado"),
 ):
@@ -728,8 +707,7 @@ def doctor():
 
         # Verificar modelo
         embedding_backend = get_default_embedding()
-        typer.echo(
-            f"✓ Backend operacional: {type(embedding_backend).__name__}")
+        typer.echo(f"✓ Backend operacional: {type(embedding_backend).__name__}")
 
         # Verificar calibración
         if embedding_backend.calibration_card:

--- a/tests/test_sota_embedding_requirements.py
+++ b/tests/test_sota_embedding_requirements.py
@@ -1,12 +1,12 @@
 """Unit tests for SotaEmbedding dependency handling."""
 
+import importlib.metadata
 import os
 import tempfile
 from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import importlib.metadata
 import numpy as np
 
 from embedding_model import EmbeddingConfig, SotaEmbedding
@@ -29,7 +29,9 @@ def test_sota_embedding_instantiates_with_declared_requirements():
 
     with patch("importlib.metadata.version", side_effect=fake_version):
         with patch("embedding_model.torch") as mock_torch:
-            with patch("embedding_model.SentenceTransformer") as mock_sentence_transformer:
+            with patch(
+                "embedding_model.SentenceTransformer"
+            ) as mock_sentence_transformer:
                 mock_torch.cuda.is_available.return_value = False
                 mock_torch.device.side_effect = lambda dev: SimpleNamespace(type=dev)
                 mock_torch.inference_mode.return_value = nullcontext()


### PR DESCRIPTION
## Summary
- align NoveltyGuard's dependency checks with the versions declared in requirements.txt and emit warnings for optional extras
- add a focused pytest covering SotaEmbedding initialization in an environment that only satisfies the declared requirements

## Testing
- pytest tests/test_sota_embedding_requirements.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd548cac58832880976202a78c7936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Dependency checks now distinguish required vs optional packages: required enforce minimum versions with clear errors and upgrade guidance; optional produce non-fatal warnings with a summary.
  * Consolidated install suggestions and improved user-facing messages.
  * Added logging for default calibration artifact creation and success.
  * Minor CLI/help text tweaks and formatting cleanups; streamlined model initialization.

* **Tests**
  * Added unit tests covering dependency validation and instantiation behavior under constrained environments, using isolated temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->