### PR TITLE
Ensure embedding setup is triggered via CLI and add regression test

### DIFF
--- a/embedding_model.py
+++ b/embedding_model.py
@@ -45,6 +45,9 @@ warnings.filterwarnings("ignore", category=UserWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
+# Estado de configuración post-instalación
+_POST_INSTALL_SETUP_DONE = False
+
 # =============================================================================
 # AUDIT TRAIL
 # =============================================================================
@@ -619,6 +622,12 @@ def provide_embeddings() -> EmbeddingBackend:
 app = typer.Typer(name="pdm-embed", help="CLI para gestión de embeddings PDM")
 
 
+@app.callback()
+def main(_ctx: typer.Context):
+    """Callback principal que asegura la configuración post-instalación."""
+    post_install_setup()
+
+
 @app.command()
 def build_card(
     corpus_path: str = typer.Argument(...,
@@ -752,8 +761,23 @@ def _load_corpus_stats(corpus_path: str) -> CalibrationCorpusStats:
 # =============================================================================
 
 
-def post_install_setup():
-    """Configuración post-instalación para generar calibración base."""
+def post_install_setup(force: bool = False) -> bool:
+    """Configuración post-instalación para generar calibración base.
+
+    Args:
+        force: Si es ``True`` intenta ejecutar la configuración incluso si ya
+            fue realizada previamente.
+
+    Returns:
+        ``True`` si la configuración se ejecutó exitosamente, ``False`` en caso
+        contrario.
+    """
+
+    global _POST_INSTALL_SETUP_DONE
+
+    if _POST_INSTALL_SETUP_DONE and not force:
+        return False
+
     try:
         embedding_backend = get_default_embedding()
 
@@ -769,16 +793,15 @@ def post_install_setup():
         else:
             logger.info("✓ Calibración existente encontrada")
 
+        _POST_INSTALL_SETUP_DONE = True
+        return True
+
     except Exception as e:
         logger.warning(f"Configuración post-instalación falló: {e}")
+        if force:
+            raise
+        return False
 
-
-# =============================================================================
-# INICIALIZACIÓN AUTOMÁTICA
-# =============================================================================
-
-# Ejecutar setup post-instalación al importar
-post_install_setup()
 
 # =============================================================================
 # IMPLEMENTATION REPORT

--- a/tests/test_embedding_model_import.py
+++ b/tests/test_embedding_model_import.py
@@ -1,0 +1,33 @@
+"""Regression tests for embedding_model import side effects."""
+
+import importlib
+import sys
+import types
+
+
+def test_import_does_not_trigger_post_install_setup(monkeypatch):
+    """Importing embedding_model should not ejecutar setup ni cargar modelos."""
+
+    # Asegurarse de trabajar con un import limpio
+    original_module = sys.modules.pop("embedding_model", None)
+
+    # Simular dependencia pesada que fallaría si se instanciara
+    fake_sentence_transformers = types.ModuleType("sentence_transformers")
+    instantiation_counter = {"count": 0}
+
+    class _SentinelTransformer:
+        def __init__(self, *args, **kwargs):
+            instantiation_counter["count"] += 1
+            raise RuntimeError("SentenceTransformer should not be instantiated on import")
+
+    fake_sentence_transformers.SentenceTransformer = _SentinelTransformer
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_sentence_transformers)
+
+    try:
+        module = importlib.import_module("embedding_model")
+        assert instantiation_counter["count"] == 0
+        assert not getattr(module, "_POST_INSTALL_SETUP_DONE", True)
+    finally:
+        sys.modules.pop("embedding_model", None)
+        if original_module is not None:
+            sys.modules["embedding_model"] = original_module


### PR DESCRIPTION
## Summary
- gate the post-installation setup behind an explicit CLI callback and make it idempotent with a force option
- skip automatic setup on module import to avoid unexpected model loading side effects
- add a regression test that imports `embedding_model` under a stubbed dependency to ensure no eager network/model loading occurs

## Testing
- pytest tests/test_embedding_model_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd548dfb488328a7c0bc25c0d577b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a command-line entry point to explicitly run post-install setup when starting the app.
- Refactor
  - Changed post-install flow to run only when invoked, preventing automatic execution during import and avoiding repeated work.
  - Improved logging and error handling, including an option to force re-run.
- Tests
  - Added regression tests to ensure importing the module has no side effects and does not instantiate heavy dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->