### PR TITLE
Fix joblib availability flag indentation

### DIFF
--- a/feasibility_scorer.py
+++ b/feasibility_scorer.py
@@ -71,7 +71,7 @@ except ImportError:
 try:
     from joblib import Parallel, delayed
 
-JOBLIB_AVAILABLE = True
+    JOBLIB_AVAILABLE = True
 except ImportError:
     JOBLIB_AVAILABLE = False
 


### PR DESCRIPTION
## Summary
- restore the `JOBLIB_AVAILABLE` flag assignment to the joblib import try block in `feasibility_scorer`
- prevent the module from raising a SyntaxError during import when joblib is unavailable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd6307af488328a9dcba309413c454